### PR TITLE
Fe adhoc bugfixes: Hides sourcemap; Hides testing error

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "GENERATE_SOURCEMAP=false react-scripts build",
     "clean": "rm -rf node_modules && yarn install",
     "predeploy": "yarn clean && yarn build",
     "deploy": "gh-pages -d build",

--- a/src/pages/EarnTri/Manage.tsx
+++ b/src/pages/EarnTri/Manage.tsx
@@ -105,7 +105,7 @@ export default function Manage({
   const stakingInfo = farmArr[0]
   let backgroundColor: string
   let token: Token | undefined
-  const totalSupplyOfStakingToken = useTotalSupply(stakingInfo?.stakedAmount?.token)
+  // const totalSupplyOfStakingToken = useTotalSupply(stakingInfo?.stakedAmount?.token)
 
   const totalStakedInUSD = stakingInfo.totalStakedInUSD.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
   const totalRewardRate = stakingInfo.totalRewardRate.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')


### PR DESCRIPTION
## 1. Generated Sourcemaps
Before hiding source maps:
<img width="1575" alt="image" src="https://user-images.githubusercontent.com/94581898/143790712-c2c3d9cd-1c76-491d-8038-4100d8b2e21e.png">
<img width="765" alt="image" src="https://user-images.githubusercontent.com/94581898/143790728-8d1faf28-dee7-4ecf-a3fe-eaef83c09de8.png">


After hiding source maps:
<img width="1484" alt="image" src="https://user-images.githubusercontent.com/94581898/143790744-698c566f-6550-4ce1-bab2-9509c2a9e0e9.png">
<img width="633" alt="image" src="https://user-images.githubusercontent.com/94581898/143790752-84b25771-6db1-4dad-833a-6c96a0939755.png">

Note: verbose errors will still be present in `yarn start`

## 2. Fixes `Error: Invalid 'address' parameter '0x0000000000000000000000000000000000000000'`
Error throws in `totalSupplyOfStakingToken`.  Variable isn't used; commented it out for now.

Error surfaced from discord: https://discord.com/channels/891278173877186571/897678352813535282/913833968292478987