### PR TITLE
Restores $ amount on staked pools

### DIFF
--- a/src/pages/EarnTri/Manage.tsx
+++ b/src/pages/EarnTri/Manage.tsx
@@ -251,33 +251,14 @@ export default function Manage({
                   <TYPE.white fontWeight={600}>{t('earnPage.liquidityDeposits')}</TYPE.white>
                 </RowBetween>
                 <RowBetween style={{ alignItems: 'baseline' }}>
-                  {(chefVersion == 1)
-                    ? (
-                      // If MasterChefV2, only show the TLP Amount (no $ amount)
-                      <>
-                        <AutoColumn gap="md">
-                          <TYPE.white fontSize={36} fontWeight={600}>
-                            {stakingInfo?.stakedAmount?.toSignificant(6) ?? '-'}
-                          </TYPE.white>
-                        </AutoColumn>
-                        <TYPE.white>
-                          TLP {currencyA?.symbol}-{currencyB?.symbol}
-                        </TYPE.white>
-                      </>
-                    )
-                    : (
-                      // If MasterChefV1, show $ amount as primary text and TLP amount as secondary text
-                      <>
-                        <AutoColumn gap="md">
-                          <TYPE.white fontSize={36} fontWeight={600}>
-                            {userLPAmountUSDFormatted ?? '$0'}
-                          </TYPE.white>
-                        </AutoColumn>
-                        <TYPE.white>
-                          {stakingInfo?.stakedAmount?.toSignificant(6) ?? '-'} TLP {currencyA?.symbol}-{currencyB?.symbol}
-                        </TYPE.white>
-                      </>
-                    )}
+                  <AutoColumn gap="md">
+                    <TYPE.white fontSize={36} fontWeight={600}>
+                      {userLPAmountUSDFormatted ?? '$0'}
+                    </TYPE.white>
+                  </AutoColumn>
+                  <TYPE.white>
+                    {stakingInfo?.stakedAmount?.toSignificant(6) ?? '-'} TLP {currencyA?.symbol}-{currencyB?.symbol}
+                  </TYPE.white>
                 </RowBetween>
               </AutoColumn>
             </CardSection>


### PR DESCRIPTION
## Shows $ and TLP
<img width="877" alt="Screen Shot 2021-12-13 at 6 37 17 AM" src="https://user-images.githubusercontent.com/94581898/145837342-135e087f-28dd-41da-8759-753d5f1a2072.png">

## Confirmed calculated $ amount (Little off, calculated price after ~10mins)

<img width="523" alt="Screen Shot 2021-12-13 at 6 38 38 AM" src="https://user-images.githubusercontent.com/94581898/145837337-137bc2d2-4fdc-4432-8999-2018c6812a92.png">
<img width="523" alt="Screen Shot 2021-12-13 at 6 38 38 AM" src="https://user-images.githubusercontent.com/94581898/145837313-6b8e78d5-58e9-4785-ac28-a428703b8408.png">