### PR TITLE
Fix flashing poolcards

### DIFF
--- a/src/components/PositionCard/index.tsx
+++ b/src/components/PositionCard/index.tsx
@@ -16,7 +16,7 @@ import { ButtonPrimary, ButtonEmpty } from '../Button'
 import { transparentize } from 'polished'
 import { CardNoise } from '../earn/styled'
 
-import { useColor } from '../../hooks/useColor'
+import { useColorWithDefault } from '../../hooks/useColor'
 
 import Card, { GreyCard, LightCard } from '../Card'
 import { AutoColumn } from '../Column'
@@ -187,7 +187,7 @@ export default function FullPositionCard({ pair, border }: PositionCardProps) {
         ]
       : [undefined, undefined]
 
-  const backgroundColor = useColor(pair?.token0)
+  const backgroundColor = useColorWithDefault('#2172E5', pair?.token0);
 
   return (
     <StyledPositionCard border={border} bgColor={backgroundColor}>

--- a/src/components/earn/PoolCard.tsx
+++ b/src/components/earn/PoolCard.tsx
@@ -7,7 +7,7 @@ import DoubleCurrencyLogo from '../DoubleLogo'
 import { CETH, Token } from '@trisolaris/sdk'
 import { ButtonPrimary } from '../Button'
 import { Staking, StakingInfo } from '../../state/stake/hooks'
-import { useColor } from '../../hooks/useColor'
+import { useColorWithDefault } from '../../hooks/useColor'
 import { currencyId } from '../../utils/currencyId'
 import { Break, CardNoise, CardBGImage } from './styled'
 import { unwrappedToken } from '../../utils/wrappedCurrency'
@@ -108,7 +108,7 @@ export default function PoolCard({
       : token0
 
   // get the color of the token
-  const backgroundColor = useColor(token)
+  const backgroundColor = useColorWithDefault('#2172E5', token);
 
   return (
     <Wrapper showBackground={isStaking} bgColor={backgroundColor}>

--- a/src/components/earn/PoolCardTri.tsx
+++ b/src/components/earn/PoolCardTri.tsx
@@ -43,11 +43,12 @@ const Wrapper = styled(AutoColumn)<{ showBackground: boolean; bgColor1: any; bgC
   width: 100%;
   overflow: hidden;
   position: relative;
-  opacity: ${({ showBackground }) => (showBackground ? '1' : '1')};
+  opacity: 1;
   background: ${({ theme, bgColor1, bgColor2, showBackground }) =>
     bgColor2 != null
       ? `radial-gradient(91.85% 100% at 1.84% 0%, ${bgColor1} 30%, ${bgColor2} 70%, ${showBackground ? theme.black : theme.bg5} 100%)`
       : `radial-gradient(91.85% 100% at 1.84% 0%, ${bgColor1} 0%, ${showBackground ? theme.black : theme.bg5} 100%) `};
+  background-color: grey;
   color: ${({ theme, showBackground }) => (showBackground ? theme.white : theme.text1)} !important;
 
   ${({ showBackground }) =>
@@ -99,12 +100,23 @@ export default function PoolCard({ stakingInfo, version }: { stakingInfo: Stakin
       : token0
 
   // get the color of the token
-  const backgroundColor1 = useColor(token)
+  let backgroundColor1 = useColor(token)
   const backgroundColor2 = useColor(token === token1 ? token0 : token1)
 
   const totalStakedInUSD = stakingInfo.totalStakedInUSD.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
 
   const isDualRewards = stakingInfo.chefVersion == 1
+
+  // Colors are dynamically chosen based on token logos
+  // These tokens are mostly grey; Override color to blue
+  if ([
+    'ETH',
+    'WETH',
+    'WBTC',
+    'WNEAR'
+  ].includes(token?.symbol ?? '')) {
+    backgroundColor1 = '#2172E5';
+  }
 
   return (
     <Wrapper showBackground={isStaking} bgColor1={backgroundColor1} bgColor2={isDualRewards ? backgroundColor2 : null}>

--- a/src/components/earn/PoolCardTri.tsx
+++ b/src/components/earn/PoolCardTri.tsx
@@ -80,6 +80,8 @@ const BottomSection = styled.div<{ showBackground: boolean }>`
   z-index: 1;
 `
 
+const GREY_ICON_TOKENS = ['ETH', 'WETH', 'WBTC', 'WNEAR'];
+
 export default function PoolCard({ stakingInfo, version }: { stakingInfo: StakingTri; version: number }) {
   const token0 = stakingInfo.tokens[0]
   const token1 = stakingInfo.tokens[1]
@@ -101,7 +103,8 @@ export default function PoolCard({ stakingInfo, version }: { stakingInfo: Stakin
 
   // get the color of the token
   let backgroundColor1 = useColor(token)
-  const backgroundColor2 = useColor(token === token1 ? token0 : token1)
+  const secondaryToken = token === token1 ? token0 : token1;
+  let backgroundColor2 = useColor(secondaryToken);
 
   const totalStakedInUSD = stakingInfo.totalStakedInUSD.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
 
@@ -109,13 +112,14 @@ export default function PoolCard({ stakingInfo, version }: { stakingInfo: Stakin
 
   // Colors are dynamically chosen based on token logos
   // These tokens are mostly grey; Override color to blue
-  if ([
-    'ETH',
-    'WETH',
-    'WBTC',
-    'WNEAR'
-  ].includes(token?.symbol ?? '')) {
+  
+  if (GREY_ICON_TOKENS.includes(token?.symbol ?? '')) {
     backgroundColor1 = '#2172E5';
+  }
+  
+  // Only override `backgroundColor2` if it's a dual rewards pool
+  if (isDualRewards && GREY_ICON_TOKENS.includes(secondaryToken?.symbol ?? '')) {
+    backgroundColor2 = '#2172E5';
   }
 
   return (

--- a/src/components/earn/styled.ts
+++ b/src/components/earn/styled.ts
@@ -26,6 +26,7 @@ export const DataCard = styled(AutoColumn) <{ disabled?: boolean }>`
 
 export const CardBGImage = styled.span<{ desaturate?: boolean }>`
    background: url(${uImage});
+   background-color: #3f4e66; // This is the average color of "uImage"
    width: 1000px;
    height: 600px;
    position: absolute;
@@ -35,12 +36,13 @@ export const CardBGImage = styled.span<{ desaturate?: boolean }>`
    left: -100px;
    transform: rotate(-15deg);
    user-select: none;
-
+   
    ${({ desaturate }) => desaturate && `filter: saturate(0)`}
- `
-
-export const CardBGImageSmaller = styled.span<{ desaturate?: boolean }>`
+   `
+   
+   export const CardBGImageSmaller = styled.span<{ desaturate?: boolean }>`
    background: url(${xlUnicorn});
+   background-color: #858585; // This is the average color of "xlUnicorn"
    width: 1200px;
    height: 1200px;
    position: absolute;
@@ -49,12 +51,13 @@ export const CardBGImageSmaller = styled.span<{ desaturate?: boolean }>`
    left: -300px;
    opacity: 0.4;
    user-select: none;
-
+   
    ${({ desaturate }) => desaturate && `filter: saturate(0)`}
- `
-
-export const CardNoise = styled.span`
+   `
+   
+   export const CardNoise = styled.span`
    background: url(${noise});
+   background-color: #858585; // This is the average color of "noise"
    background-size: cover;
    mix-blend-mode: overlay;
    border-radius: 12px;

--- a/src/hooks/useColor.ts
+++ b/src/hooks/useColor.ts
@@ -4,7 +4,13 @@ import Vibrant from 'node-vibrant'
 import { hex } from 'wcag-contrast'
 import { Token } from '@trisolaris/sdk'
 
+const COLOR_MAP = new Map();
+
 async function getColorFromToken(token: Token): Promise<string | null> {
+  if (COLOR_MAP.has(token.address)) {
+    return COLOR_MAP.get(token.address);
+  }
+
   const path = `https://raw.githubusercontent.com/trisolaris-labs/tokens/master/assets/${token.address}/logo.png`
 
   return Vibrant.from(path)
@@ -21,11 +27,18 @@ async function getColorFromToken(token: Token): Promise<string | null> {
       }
       return null
     })
+    .then(color => {
+      if (color != null) {
+        COLOR_MAP.set(token.address, color);
+      }
+
+      return color;
+    })
     .catch(() => null)
 }
 
 export function useColor(token?: Token) {
-  const [color, setColor] = useState('#2172E5')
+  const [color, setColor] = useState<string | null>(null);
 
   useLayoutEffect(() => {
     let stale = false
@@ -40,9 +53,13 @@ export function useColor(token?: Token) {
 
     return () => {
       stale = true
-      setColor('#2172E5')
+      setColor(null);
     }
   }, [token])
 
-  return color
+  return color;
+}
+
+export function useColorWithDefault(defaultColor: string, token?: Token) {
+  return useColor(token) ?? defaultColor;
 }

--- a/src/pages/EarnTri/Manage.tsx
+++ b/src/pages/EarnTri/Manage.tsx
@@ -18,7 +18,7 @@ import UnstakingModal from '../../components/earn/UnstakingModalTri'
 import ClaimRewardModal from '../../components/earn/ClaimRewardModalTri'
 import { useTokenBalance } from '../../state/wallet/hooks'
 import { useActiveWeb3React } from '../../hooks'
-import { useColor } from '../../hooks/useColor'
+import { useColorWithDefault } from '../../hooks/useColor'
 import { CountUp } from 'use-count-up'
 
 import { wrappedCurrency } from '../../utils/wrappedCurrency'
@@ -110,7 +110,7 @@ export default function Manage({
   const totalRewardRate = stakingInfo.totalRewardRate.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
 
   // get the color of the token
-  backgroundColor = useColor(token)
+  backgroundColor = useColorWithDefault('#2172E5', token);
 
   // detect existing unstaked LP position to show add button if none found
   const userLiquidityUnstaked = useTokenBalance(account ?? undefined, stakingInfo?.stakedAmount?.token)


### PR DESCRIPTION
- Fixes cards flashing
- Fixes cards showing as blue radial gradient before loading token colors
- Fixes ETH/WNEAR/WBTC tokens being all grey


https://user-images.githubusercontent.com/94581898/145920088-e540734c-ac67-47f3-bd2e-c3117f83c7d1.mov


### Eth/Wnear cards before
![image](https://user-images.githubusercontent.com/94581898/145919051-2a7cb7a7-a3b6-4c47-9636-7252804775a3.png)

### After
![image](https://user-images.githubusercontent.com/94581898/145919965-a0d49d91-fee0-4710-a1ef-06b23bb3ebfc.png)



