### PR TITLE
Update logic to calculate total $ in pool for a user

### DIFF
--- a/src/data/TotalStakedInPool.ts
+++ b/src/data/TotalStakedInPool.ts
@@ -1,0 +1,22 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { Token, TokenAmount, ChainId } from '@trisolaris/sdk'
+import { AURORA } from '../constants'
+import { ChefVersions } from '../state/stake/stake-constants'
+import { MASTERCHEF_ADDRESS_V1,MASTERCHEF_ADDRESS_V2 } from '../state/stake/hooks-sushi'
+import { useTokenContract } from '../hooks/useContract'
+import { useSingleCallResult } from '../state/multicall/hooks'
+
+
+// returns undefined if input token is undefined, or fails to get token contract,
+// or contract total supply cannot be fetched
+export function useTotalStakedInPool(token?: Token, version?: ChefVersions): TokenAmount | undefined {
+
+  const masterChefAddress = version === ChefVersions.V1
+    ? MASTERCHEF_ADDRESS_V1[ChainId.AURORA]
+    : MASTERCHEF_ADDRESS_V2[ChainId.AURORA];
+
+  const contract = useTokenContract(token?.address, false)
+  const totalStakedInPool: BigNumber = useSingleCallResult(contract, 'balanceOf', [masterChefAddress])?.result?.[0]
+
+  return token && totalStakedInPool ? new TokenAmount(token, totalStakedInPool.toString()) : undefined
+}

--- a/src/data/TotalStakedInPool.ts
+++ b/src/data/TotalStakedInPool.ts
@@ -1,6 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { Token, TokenAmount, ChainId } from '@trisolaris/sdk'
-import { AURORA } from '../constants'
 import { ChefVersions } from '../state/stake/stake-constants'
 import { MASTERCHEF_ADDRESS_V1,MASTERCHEF_ADDRESS_V2 } from '../state/stake/hooks-sushi'
 import { useTokenContract } from '../hooks/useContract'

--- a/src/data/TotalSupply.ts
+++ b/src/data/TotalSupply.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { Token, TokenAmount } from '@trisolaris/sdk'
+import { Token, TokenAmount, ChainId } from '@trisolaris/sdk'
 import { useTokenContract } from '../hooks/useContract'
 import { useSingleCallResult } from '../state/multicall/hooks'
 

--- a/src/data/TotalSupply.ts
+++ b/src/data/TotalSupply.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { Token, TokenAmount, ChainId } from '@trisolaris/sdk'
+import { Token, TokenAmount } from '@trisolaris/sdk'
 import { useTokenContract } from '../hooks/useContract'
 import { useSingleCallResult } from '../state/multicall/hooks'
 

--- a/src/pages/EarnTri/Manage.tsx
+++ b/src/pages/EarnTri/Manage.tsx
@@ -146,6 +146,7 @@ export default function Manage({
     lpToken,
     userLPStakedAmount: stakingInfo?.stakedAmount,
     totalPoolAmountUSD: stakingInfo?.totalStakedInUSD,
+    chefVersion: stakingInfo?.chefVersion,
   }) ?? {};
 
   const handleDepositClick = useCallback(() => {

--- a/src/state/stake/useUserFarmStatistics.ts
+++ b/src/state/stake/useUserFarmStatistics.ts
@@ -1,6 +1,7 @@
 import { JSBI, Token, TokenAmount } from '@trisolaris/sdk';
 import { useTotalStakedInPool } from '../../data/TotalStakedInPool';
 import { ChefVersions } from './stake-constants'
+import { addCommasToNumber } from '../../utils';
 
 type Props = {
     lpToken?: Token,
@@ -30,7 +31,7 @@ export default function useUserFarmStatistics({
     const userLPShare = userLPStakedAmount.divide(totalStakedInPool);
     const userLPAmountUSD = userLPShare?.multiply(JSBI.BigInt(totalPoolAmountUSD));
     const userLPAmountUSDFormatted = userLPAmountUSD != null
-        ? `$${userLPAmountUSD?.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',')}`
+        ? `$${addCommasToNumber(userLPAmountUSD.toFixed(2))}`
         : null;
 
     return {

--- a/src/state/stake/useUserFarmStatistics.ts
+++ b/src/state/stake/useUserFarmStatistics.ts
@@ -1,21 +1,24 @@
 import { JSBI, Token, TokenAmount } from '@trisolaris/sdk';
-import { useTotalSupply } from '../../data/TotalSupply';
+import { useTotalStakedInPool } from '../../data/TotalStakedInPool';
+import { ChefVersions } from './stake-constants'
 
 type Props = {
     lpToken?: Token,
     userLPStakedAmount?: TokenAmount | null,
     totalPoolAmountUSD?: number,
+    chefVersion?: ChefVersions,
 }
 
 export default function useUserFarmStatistics({
     lpToken,
     userLPStakedAmount,
     totalPoolAmountUSD,
+    chefVersion,
 }: Props) {
-    const totalSupply = useTotalSupply(lpToken);
+    const totalStakedInPool = useTotalStakedInPool(lpToken, chefVersion);
 
     if (
-        totalSupply == null ||
+        totalStakedInPool == null ||
         lpToken == null ||
         userLPStakedAmount == null ||
         totalPoolAmountUSD == null ||
@@ -24,14 +27,14 @@ export default function useUserFarmStatistics({
         return null;
     }
 
-    const userLPShare = userLPStakedAmount.divide(totalSupply);
+    const userLPShare = userLPStakedAmount.divide(totalStakedInPool);
     const userLPAmountUSD = userLPShare?.multiply(JSBI.BigInt(totalPoolAmountUSD));
     const userLPAmountUSDFormatted = userLPAmountUSD != null
         ? `$${userLPAmountUSD?.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',')}`
         : null;
 
     return {
-        totalSupply,
+        totalStakedInPool,
         userLPShare,
         userLPAmountUSD,
         userLPAmountUSDFormatted,


### PR DESCRIPTION
- updated logic to divide by totalLPStakedInPool instead of TotalLP (staked or unstaked) to give more accurate calculation

Before

![Screen Shot 2021-12-24 at 2 22 35 PM](https://user-images.githubusercontent.com/89817711/147370073-a82a3783-a25b-4318-85a9-f3a70f82802b.png)

After
![Screen Shot 2021-12-24 at 2 22 54 PM](https://user-images.githubusercontent.com/89817711/147370079-90c8a17e-5265-4c36-b9b1-dae32f14dba0.png)

