### PR TITLE
Move settings button from header to Swap menu.

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -11,7 +11,6 @@ import { useActiveWeb3React } from '../../hooks'
 import { ButtonSecondary } from '../Button'
 
 import { RedCard } from '../Card'
-import Settings from '../Settings'
 import Menu from '../Menu'
 import BridgesMenu from '../BridgesMenu'
 
@@ -308,7 +307,6 @@ export default function Header() {
           </AccountElement>
         </HeaderElement>
         <HeaderElementWrap>
-          <Settings />
           <Menu />
         </HeaderElementWrap>
       </HeaderControls>

--- a/src/components/Settings/Settings.styles.tsx
+++ b/src/components/Settings/Settings.styles.tsx
@@ -1,0 +1,56 @@
+import styled from 'styled-components'
+import { Settings, X } from 'react-feather'
+
+import { MenuFlyout } from '../StyledMenu'
+
+export const StyledMenuIcon = styled(Settings)`
+  height: 20px;
+  width: 20px;
+
+  > * {
+    stroke: ${({ theme }) => theme.text1};
+  }
+`
+
+export const StyledCloseIcon = styled(X)`
+  height: 20px;
+  width: 20px;
+
+  :hover {
+    cursor: pointer;
+  }
+
+  > * {
+    stroke: ${({ theme }) => theme.text1};
+  }
+`
+
+export const EmojiWrapper = styled.div`
+  position: absolute;
+  bottom: -6px;
+  right: 0px;
+  font-size: 14px;
+`
+
+export const Break = styled.div`
+  width: 100%;
+  height: 1px;
+  background-color: ${({ theme }) => theme.bg3};
+`
+
+export const ModalContentWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 0;
+  background-color: ${({ theme }) => theme.bg2};
+  border-radius: 20px;
+`
+
+export const SettingsMenuFlyout = styled(MenuFlyout)`
+  top: 3rem;
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+    min-width: 18.125rem;
+    right: 0.15rem;
+  `};
+`

--- a/src/components/Settings/Settings.styles.tsx
+++ b/src/components/Settings/Settings.styles.tsx
@@ -49,6 +49,7 @@ export const ModalContentWrapper = styled.div`
 
 export const SettingsMenuFlyout = styled(MenuFlyout)`
   top: 3rem;
+  border: ${({ theme }) => `1px solid ${theme.bg3}`};
   ${({ theme }) => theme.mediaWidth.upToMedium`
     min-width: 18.125rem;
     right: 0.15rem;

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -1,82 +1,31 @@
-import React, {useContext, useRef, useState} from 'react'
-import {Settings, X} from 'react-feather'
-import {Text} from 'rebass'
-import styled, {ThemeContext} from 'styled-components'
-import {useOnClickOutside} from '../../hooks/useOnClickOutside'
-import {ApplicationModal} from '../../state/application/actions'
-import {useModalOpen, useToggleSettingsMenu} from '../../state/application/hooks'
-import {
-  useExpertModeManager,
-  useUserTransactionTTL,
-  useUserSlippageTolerance
-} from '../../state/user/hooks'
-import {TYPE} from '../../theme'
-import {ButtonError} from '../Button'
-import {AutoColumn} from '../Column'
+import React, { useContext, useRef, useState } from 'react'
+import { Text } from 'rebass'
+import { ThemeContext } from 'styled-components'
+import { useTranslation } from 'react-i18next'
+
+import { TYPE } from '../../theme'
+import { ButtonError } from '../Button'
+import { AutoColumn } from '../Column'
 import Modal from '../Modal'
 import QuestionHelper from '../QuestionHelper'
-import {RowBetween, RowFixed} from '../Row'
+import { RowBetween, RowFixed } from '../Row'
 import Toggle from '../Toggle'
 import TransactionSettings from '../TransactionSettings'
-import {useTranslation} from 'react-i18next'
-import {StyledMenu, StyledMenuButton, MenuFlyout} from "../StyledMenu";
 
-const StyledMenuIcon = styled(Settings)`
-  height: 20px;
-  width: 20px;
+import { ApplicationModal } from '../../state/application/actions'
+import { useModalOpen, useToggleSettingsMenu } from '../../state/application/hooks'
+import { useExpertModeManager, useUserTransactionTTL, useUserSlippageTolerance } from '../../state/user/hooks'
+import { useOnClickOutside } from '../../hooks/useOnClickOutside'
 
-  > * {
-    stroke: ${({theme}) => theme.text1};
-  }
-`
-
-const StyledCloseIcon = styled(X)`
-  height: 20px;
-  width: 20px;
-
-  :hover {
-    cursor: pointer;
-  }
-
-  > * {
-    stroke: ${({theme}) => theme.text1};
-  }
-`
-
-const EmojiWrapper = styled.div`
-  position: absolute;
-  bottom: -6px;
-  right: 0px;
-  font-size: 14px;
-`
-
-const Break = styled.div`
-  width: 100%;
-  height: 1px;
-  background-color: ${({theme}) => theme.bg3};
-`
-
-const ModalContentWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2rem 0;
-  background-color: ${({theme}) => theme.bg2};
-  border-radius: 20px;
-`
-
-const SettingsMenuFlyout = styled(MenuFlyout)`
-
-  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
-    min-width: 18.125rem;
-    right: -46px;
-  `};
-
-  ${({ theme }) => theme.mediaWidth.upToMedium`
-    min-width: 18.125rem;
-    top: -22rem;
-  `};
-`
+import { StyledMenu, StyledMenuButton } from '../StyledMenu'
+import {
+  StyledMenuIcon,
+  StyledCloseIcon,
+  EmojiWrapper,
+  Break,
+  ModalContentWrapper,
+  SettingsMenuFlyout
+} from './Settings.styles'
 
 export default function SettingsTab() {
   const node = useRef<HTMLDivElement>()
@@ -95,22 +44,22 @@ export default function SettingsTab() {
 
   useOnClickOutside(node, open ? toggle : undefined)
 
-  const {t} = useTranslation()
+  const { t } = useTranslation()
   return (
     // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30451
     <StyledMenu ref={node as any}>
       <Modal isOpen={showConfirmation} onDismiss={() => setShowConfirmation(false)} maxHeight={100}>
         <ModalContentWrapper>
           <AutoColumn gap="lg">
-            <RowBetween style={{padding: '0 2rem'}}>
-              <div/>
+            <RowBetween style={{ padding: '0 2rem' }}>
+              <div />
               <Text fontWeight={500} fontSize={20}>
                 {t('settings.areYouSure')}
               </Text>
-              <StyledCloseIcon onClick={() => setShowConfirmation(false)}/>
+              <StyledCloseIcon onClick={() => setShowConfirmation(false)} />
             </RowBetween>
-            <Break/>
-            <AutoColumn gap="lg" style={{padding: '0 2rem'}}>
+            <Break />
+            <AutoColumn gap="lg" style={{ padding: '0 2rem' }}>
               <Text fontWeight={500} fontSize={20}>
                 {t('settings.expertInfo')}
               </Text>
@@ -136,7 +85,7 @@ export default function SettingsTab() {
         </ModalContentWrapper>
       </Modal>
       <StyledMenuButton onClick={toggle} id="open-settings-dialog-button">
-        <StyledMenuIcon/>
+        <StyledMenuIcon />
         {expertMode ? (
           <EmojiWrapper>
             <span role="img" aria-label="wizard-icon">
@@ -147,7 +96,7 @@ export default function SettingsTab() {
       </StyledMenuButton>
       {open && (
         <SettingsMenuFlyout>
-          <AutoColumn gap="md" style={{padding: '1rem'}}>
+          <AutoColumn gap="md" style={{ padding: '1rem' }}>
             <Text fontWeight={600} fontSize={14}>
               {t('settings.transactionSettings')}
             </Text>
@@ -165,7 +114,7 @@ export default function SettingsTab() {
                 <TYPE.black fontWeight={400} fontSize={14} color={theme.text2}>
                   {t('settings.toggleExpertMode')}
                 </TYPE.black>
-                <QuestionHelper text={t('settings.expertModeHelper')}/>
+                <QuestionHelper text={t('settings.expertModeHelper')} />
               </RowFixed>
               <Toggle
                 id="toggle-expert-mode-button"
@@ -173,13 +122,13 @@ export default function SettingsTab() {
                 toggle={
                   expertMode
                     ? () => {
-                      toggleExpertMode()
-                      setShowConfirmation(false)
-                    }
+                        toggleExpertMode()
+                        setShowConfirmation(false)
+                      }
                     : () => {
-                      toggle()
-                      setShowConfirmation(true)
-                    }
+                        toggle()
+                        setShowConfirmation(true)
+                      }
                 }
               />
             </RowBetween>

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -19,7 +19,7 @@ import { ChevronWrapper, BottomGrouping, SwapCallbackError, Wrapper } from '../.
 import TradePrice from '../../components/swap/TradePrice'
 import TokenWarningModal from '../../components/TokenWarningModal'
 import ProgressSteps from '../../components/ProgressSteps'
-import spacemenAndPlanets from '../../assets/svg/spacemen_and_planets.svg';
+import spacemenAndPlanets from '../../assets/svg/spacemen_and_planets.svg'
 
 import { INITIAL_ALLOWED_SLIPPAGE } from '../../constants'
 import { useActiveWeb3React } from '../../hooks'
@@ -47,6 +47,7 @@ import useENS from '../../hooks/useENS'
 import { useTranslation } from 'react-i18next'
 import { useIsSelectedAEBToken } from '../../state/lists/hooks'
 import { DeprecatedWarning } from '../../components/Warning'
+import Settings from '../../components/Settings'
 
 const BottomText = styled.span`
   margin-top: 8px;
@@ -92,14 +93,20 @@ const SwapContainer = styled.div`
 const IconContainer = styled.div`
   margin-right: 10em;
 
-    ${({ theme }) => theme.mediaWidth.upToMedium`
+  ${({ theme }) => theme.mediaWidth.upToMedium`
       display: none;
   `};
-    ${({ theme }) => theme.mediaWidth.upToLarge`
+  ${({ theme }) => theme.mediaWidth.upToLarge`
         & > * {
             height: 400px;
         }
   `};
+`
+
+const HeadingContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 `
 
 export default function Swap() {
@@ -162,13 +169,13 @@ export default function Swap() {
 
   const parsedAmounts = showWrap
     ? {
-      [Field.INPUT]: parsedAmount,
-      [Field.OUTPUT]: parsedAmount
-    }
+        [Field.INPUT]: parsedAmount,
+        [Field.OUTPUT]: parsedAmount
+      }
     : {
-      [Field.INPUT]: independentField === Field.INPUT ? parsedAmount : trade?.inputAmount,
-      [Field.OUTPUT]: independentField === Field.OUTPUT ? parsedAmount : trade?.outputAmount
-    }
+        [Field.INPUT]: independentField === Field.INPUT ? parsedAmount : trade?.inputAmount,
+        [Field.OUTPUT]: independentField === Field.OUTPUT ? parsedAmount : trade?.outputAmount
+      }
 
   const { onSwitchTokens, onCurrencySelection, onUserInput, onChangeRecipient } = useSwapActionHandlers()
   const isValid = !swapInputError
@@ -254,8 +261,8 @@ export default function Swap() {
             recipient === null
               ? 'Swap w/o Send'
               : (recipientAddress ?? recipient) === account
-                ? 'Swap w/o Send + recipient'
-                : 'Swap w/ Send',
+              ? 'Swap w/o Send + recipient'
+              : 'Swap w/ Send',
           label: [trade?.inputAmount?.currency?.symbol, trade?.outputAmount?.currency?.symbol, Version.v2].join('/')
         })
       })
@@ -350,11 +357,12 @@ export default function Swap() {
                 swapErrorMessage={swapErrorMessage}
                 onDismiss={handleConfirmDismiss}
               />
-
               <AutoColumn gap={'md'}>
-                <TYPE.largeHeader>
-                  Swap
-                </TYPE.largeHeader>
+                <HeadingContainer>
+                  <TYPE.largeHeader>Swap</TYPE.largeHeader>
+                  <Settings />
+                </HeadingContainer>
+
                 <CurrencyInputPanel
                   label={
                     independentField === Field.OUTPUT && !showWrap && trade
@@ -393,7 +401,9 @@ export default function Swap() {
                   value={formattedAmounts[Field.OUTPUT]}
                   onUserInput={handleTypeOutput}
                   label={
-                    independentField === Field.INPUT && !showWrap && trade ? t('swapPage.toEstimated') : t('swapPage.to')
+                    independentField === Field.INPUT && !showWrap && trade
+                      ? t('swapPage.toEstimated')
+                      : t('swapPage.to')
                   }
                   showMaxButton={false}
                   currency={currencies[Field.OUTPUT]}
@@ -454,8 +464,8 @@ export default function Swap() {
                       (wrapType === WrapType.WRAP
                         ? t('swapPage.wrap')
                         : wrapType === WrapType.UNWRAP
-                          ? t('swapPage.unwrap')
-                          : null)}
+                        ? t('swapPage.unwrap')
+                        : null)}
                   </ButtonPrimary>
                 ) : noRoute && userHasSpecifiedInputOutput ? (
                   <GreyCard style={{ textAlign: 'center' }}>
@@ -531,8 +541,8 @@ export default function Swap() {
                       {swapInputError
                         ? swapInputError
                         : priceImpactSeverity > 3 && !isExpertMode
-                          ? t('swapPage.priceImpactHigh')
-                          : t('swapPage.swap') + `${priceImpactSeverity > 2 ? t('swapPage.anyway') : ''}`}
+                        ? t('swapPage.priceImpactHigh')
+                        : t('swapPage.swap') + `${priceImpactSeverity > 2 ? t('swapPage.anyway') : ''}`}
                     </Text>
                   </ButtonError>
                 )}


### PR DESCRIPTION
## Description
- Moved Settings button from Header into Swap menu.
- Separate Settings styles.
- Reorder and group Settings imports. 


## Affected components
- Header
- Settings
- 
## Affected views
- Swap

## Browsers / viewports verified
- Chrome v96 (Mac os)
- Firefox v95 (Mac os)
- Responsive
