### PR TITLE
Fix logo overlaping on very small devices.

### DIFF
--- a/src/components/BridgesMenu/BridgesMenu.styles.tsx
+++ b/src/components/BridgesMenu/BridgesMenu.styles.tsx
@@ -66,7 +66,7 @@ export const StyledArrow = styled.span`
 `
 
 export const StyledButtonText = styled.span`
-  ${({ theme }) => theme.mediaWidth.upToXxxs`
+  ${({ theme }) => theme.mediaWidth.upToXxxSmall`
     display: none;
   `}
 `

--- a/src/components/BridgesMenu/BridgesMenu.styles.tsx
+++ b/src/components/BridgesMenu/BridgesMenu.styles.tsx
@@ -64,3 +64,9 @@ export const StyledArrow = styled.span`
   font-size: 11px;
   margin-left: 0.3rem;
 `
+
+export const StyledButtonText = styled.span`
+  ${({ theme }) => theme.mediaWidth.upToXxxs`
+    display: none;
+  `}
+`

--- a/src/components/BridgesMenu/index.tsx
+++ b/src/components/BridgesMenu/index.tsx
@@ -6,7 +6,7 @@ import { useModalOpen, useToggleModal } from '../../state/application/hooks'
 import { ApplicationModal } from '../../state/application/actions'
 import { useOnClickOutside } from '../../hooks/useOnClickOutside'
 
-import { StyledMenuFlyout, StyledExternalLink, MenuButton, StyledArrow } from './BridgesMenu.styles'
+import { StyledMenuFlyout, StyledExternalLink, MenuButton, StyledArrow, StyledButtonText } from './BridgesMenu.styles'
 
 import { BRIDGES } from './BridgesMenu.constants'
 
@@ -18,7 +18,9 @@ export default function BridgesMenu() {
 
   return (
     <StyledMenu ref={node as any}>
-      <MenuButton onClick={toggle}>Bridges</MenuButton>
+      <MenuButton onClick={toggle}>
+        <StyledButtonText>Bridges</StyledButtonText>
+      </MenuButton>
 
       {open && (
         <StyledMenuFlyout>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -211,7 +211,7 @@ const StyledNavLink = styled(NavLink).attrs({
     color: ${({ theme }) => darken(0.1, theme.text1)};
   }
 
-  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+  ${({ theme }) => theme.mediaWidth.upToXxs`
     margin: 0 6px;
   `}
 `

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -94,9 +94,14 @@ const HeaderRow = styled(RowFixed)`
 
 const HeaderLinks = styled(Row)`
   justify-content: center;
+
   ${({ theme }) => theme.mediaWidth.upToMedium`
     padding: 1rem 0 1rem 1rem;
     justify-content: flex-end;
+`};
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    padding: 1rem 0;
+    justify-content: center;
 `};
 `
 
@@ -205,6 +210,10 @@ const StyledNavLink = styled(NavLink).attrs({
   :focus {
     color: ${({ theme }) => darken(0.1, theme.text1)};
   }
+
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    margin: 0 6px;
+  `}
 `
 
 const IconWrapper = styled.div<{ size?: number }>`
@@ -219,7 +228,7 @@ const IconWrapper = styled.div<{ size?: number }>`
 
 const StyledHomeNavLink = styled(StyledNavLink)`
   margin: 0 0 0 0.25rem;
-  ${({ theme }) => theme.mediaWidth.upToSmall`
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
     display:none;
   `};
 `
@@ -228,6 +237,9 @@ const HomeContainer = styled.div`
   display: flex;
   align-items: center;
   margin-right: 2rem;
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    margin-right:0;
+  `};
 `
 
 export default function Header() {
@@ -278,8 +290,8 @@ export default function Header() {
           >
             {t('header.farm')}
           </StyledNavLink>
+          <BridgesMenu />
         </HeaderLinks>
-        <BridgesMenu />
       </HeaderRow>
       <HeaderControls>
         <HeaderElement>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -211,7 +211,7 @@ const StyledNavLink = styled(NavLink).attrs({
     color: ${({ theme }) => darken(0.1, theme.text1)};
   }
 
-  ${({ theme }) => theme.mediaWidth.upToXxs`
+  ${({ theme }) => theme.mediaWidth.upToXxSmall`
     margin: 0 6px;
   `}
 `

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -13,6 +13,8 @@ import { Colors } from './styled'
 export * from './components'
 
 const MEDIA_WIDTHS = {
+  upToXxxs: 325,
+  upToXxs: 375,
   upToExtraSmall: 500,
   upToSmall: 720,
   upToMedium: 960,
@@ -116,7 +118,7 @@ export function theme(darkMode: boolean): DefaultTheme {
       flex-flow: row nowrap;
     `,
 
-    pageWidth: '720px',
+    pageWidth: '720px'
   }
 }
 

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -13,8 +13,8 @@ import { Colors } from './styled'
 export * from './components'
 
 const MEDIA_WIDTHS = {
-  upToXxxs: 325,
-  upToXxs: 375,
+  upToXxxSmall: 325,
+  upToXxSmall: 375,
   upToExtraSmall: 500,
   upToSmall: 720,
   upToMedium: 960,

--- a/src/theme/styled.d.ts
+++ b/src/theme/styled.d.ts
@@ -64,8 +64,8 @@ declare module 'styled-components' {
 
     // media queries
     mediaWidth: {
-      upToXxxs: ThemedCssFunction<DefaultTheme>
-      upToXxs: ThemedCssFunction<DefaultTheme>
+      upToXxxSmall: ThemedCssFunction<DefaultTheme>
+      upToXxSmall: ThemedCssFunction<DefaultTheme>
       upToExtraSmall: ThemedCssFunction<DefaultTheme>
       upToSmall: ThemedCssFunction<DefaultTheme>
       upToMedium: ThemedCssFunction<DefaultTheme>

--- a/src/theme/styled.d.ts
+++ b/src/theme/styled.d.ts
@@ -64,6 +64,8 @@ declare module 'styled-components' {
 
     // media queries
     mediaWidth: {
+      upToXxxs: ThemedCssFunction<DefaultTheme>
+      upToXxs: ThemedCssFunction<DefaultTheme>
       upToExtraSmall: ThemedCssFunction<DefaultTheme>
       upToSmall: ThemedCssFunction<DefaultTheme>
       upToMedium: ThemedCssFunction<DefaultTheme>


### PR DESCRIPTION
Fix Logo overlapping and small devices header improvements

Added two new breakpoints for handling small devices media queries, names can be discussed for sure

