### PR TITLE
Replaced github url with gcc url

### DIFF
--- a/src/fetchers/farms.ts
+++ b/src/fetchers/farms.ts
@@ -2,7 +2,7 @@ import useSWR from 'swr';
 import { ExternalInfo } from '../state/stake/stake-constants';
 
 async function fetcher() {
-    const response = await fetch('https://raw.githubusercontent.com/trisolaris-labs/apr/master/datav2.json')
+    const response = await fetch('https://storage.googleapis.com/trisolaris_public/datav2.json')
 
     return response.json();
 }


### PR DESCRIPTION
1. Go to https://jsoncompare.org/
2. On the left side, put `https://raw.githubusercontent.com/trisolaris-labs/apr/master/datav2.json`
3. On the right side, put `https://storage.googleapis.com/trisolaris_public/datav2.json`

Compared locally:
![image](https://user-images.githubusercontent.com/94581898/148459461-d62dbed7-94f0-46cb-834f-f61f91e2b248.png)

