### PR TITLE
refactored doublereward token

### DIFF
--- a/src/components/earn/ClaimRewardModalTri.tsx
+++ b/src/components/earn/ClaimRewardModalTri.tsx
@@ -34,6 +34,7 @@ export default function ClaimRewardModal({ isOpen, onDismiss, stakingInfo }: Sta
   const [attempting, setAttempting] = useState(false)
   const chefVersion = stakingInfo.chefVersion
   const doubleRewardsOn = stakingInfo.doubleRewards
+  const doubleRewardToken = stakingInfo.doubleRewardToken
 
   function wrappedOnDismiss() {
     setHash(undefined)
@@ -110,7 +111,7 @@ export default function ClaimRewardModal({ isOpen, onDismiss, stakingInfo }: Sta
                             <TYPE.body fontWeight={600} fontSize={36}>
                                 {stakingInfo?.doubleRewardAmount?.toSignificant(6)}
                             </TYPE.body>
-                            <TYPE.body>{"Unclaimed Aurora"}</TYPE.body>
+                            <TYPE.body>{"Unclaimed"} {doubleRewardToken.symbol}</TYPE.body>
                         </AutoColumn>
                     )}
                     <TYPE.subHeader style={{ textAlign: 'center' }}>

--- a/src/components/earn/PoolCardTri.tsx
+++ b/src/components/earn/PoolCardTri.tsx
@@ -66,6 +66,7 @@ type Props = {
     token1: Token
     totalStakedInUSD: number
     version: number
+    doubleRewardToken: Token
 }
 
 const Button = styled(ButtonPrimary) < { isStaking: boolean }>`
@@ -97,6 +98,7 @@ export default function PoolCardTRI({
     token1: _token1,
     totalStakedInUSD,
     version,
+    doubleRewardToken
 }: Props) {
     const {currency0, currency1, token0, token1} = getPairRenderOrder(_token0, _token1)
 
@@ -148,7 +150,7 @@ export default function PoolCardTRI({
                     </TYPE.mutedSubHeader>
                     <TYPE.white textAlign="end">
                         {(isDualRewards && doubleRewards
-                            ? `${apr}% TRI + ${`${apr2}%`} AURORA`
+                            ? `${apr}% TRI + ${`${apr2}%`} ${`${doubleRewardToken.symbol}`}`
                             : inStaging
                                 ? `Coming Soon`
                                 : `${apr}%`

--- a/src/components/earn/UnstakingModalTri.tsx
+++ b/src/components/earn/UnstakingModalTri.tsx
@@ -47,6 +47,7 @@ export default function UnstakingModal({ isOpen, onDismiss, stakingInfo }: Staki
   const stakingContractv2 = useMasterChefV2Contract()
   const chefVersion = stakingInfo.chefVersion
   const doubleRewardsOn = stakingInfo.doubleRewards
+  const doubleRewardToken = stakingInfo.doubleRewardToken
 
   async function onWithdraw() {
     if(stakingInfo.chefVersion == 0) {
@@ -121,7 +122,7 @@ export default function UnstakingModal({ isOpen, onDismiss, stakingInfo }: Staki
               <TYPE.body fontWeight={600} fontSize={36}>
                 {<FormattedCurrencyAmount currencyAmount={stakingInfo?.doubleRewardAmount} />}
               </TYPE.body>
-              <TYPE.body>{"Unclaimed Aurora"}</TYPE.body>
+              <TYPE.body>{"Unclaimed"} {doubleRewardToken.symbol}</TYPE.body>
             </AutoColumn>
           )}
           <TYPE.subHeader style={{ textAlign: 'center' }}>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -127,7 +127,7 @@ export const UST: { [chainId in ChainId]: Token } = {
     ChainId.AURORA,
     '0x5ce9F0B6AFb36135b5ddBF11705cEB65E634A9dC',
     18,
-    'UST',
+    'atUST',
     'Wrapped UST',
   ),
 }
@@ -140,7 +140,7 @@ export const LUNA: { [chainId in ChainId]: Token } = {
     ChainId.AURORA,
     '0xC4bdd27c33ec7daa6fcfd8532ddB524Bf4038096',
     18,
-    'LUNA',
+    'atLUNA',
     'Wrapped LUNA',
   ),
 }

--- a/src/pages/EarnTri/Manage.tsx
+++ b/src/pages/EarnTri/Manage.tsx
@@ -124,6 +124,7 @@ export default function Manage({
     tokens,
     totalRewardRate,
     totalStakedInUSD,
+    doubleRewardToken
   } = stakingInfo;
   const isDualRewards = chefVersion == 1;
 
@@ -292,7 +293,7 @@ export default function Manage({
               <RowBetween>
                 <TYPE.black>{t('earnPage.unclaimed')} TRI</TYPE.black>
                 {(isDualRewards && doubleRewards) ? (
-                  <TYPE.black>{t('earnPage.unclaimed')} AURORA</TYPE.black>
+                  <TYPE.black>{t('earnPage.unclaimed')} {doubleRewardToken.symbol}</TYPE.black>
                 ) : null}
               </RowBetween>
               <RowBetween style={{ alignItems: 'baseline' }}>

--- a/src/pages/EarnTri/index.tsx
+++ b/src/pages/EarnTri/index.tsx
@@ -123,6 +123,7 @@ export default function Earn({
               version={farm.ID}
               doubleRewards={farm.doubleRewards}
               inStaging={farm.inStaging}
+              doubleRewardToken={farm.doubleRewardToken}
             />
           ))}
         </PoolSection>
@@ -149,6 +150,7 @@ export default function Earn({
               version={farm.ID}
               doubleRewards={farm.doubleRewards}
               inStaging={farm.inStaging}
+              doubleRewardToken={farm.doubleRewardToken}
             />
           ))}
         </PoolSection>
@@ -175,6 +177,7 @@ export default function Earn({
               version={farm.ID}
               doubleRewards={farm.doubleRewards}
               inStaging={farm.inStaging}
+              doubleRewardToken={farm.doubleRewardToken}
             />
           ))}
         </PoolSection>

--- a/src/state/stake/stake-constants.ts
+++ b/src/state/stake/stake-constants.ts
@@ -37,6 +37,7 @@ export type StakingTriFarms = {
   chefVersion: ChefVersions
   doubleRewards: boolean
   inStaging: boolean
+  doubleRewardToken: Token
 }
 
 export interface ExternalInfo {
@@ -80,7 +81,8 @@ const POLYGON_POOLS: StakingTri[] = [
     apr2:0,
     chefVersion: ChefVersions.V1,
     doubleRewards: false,
-    inStaging: false
+    inStaging: false,
+    doubleRewardToken: dummyToken
   },
   {
     ID: 1,
@@ -102,7 +104,8 @@ const POLYGON_POOLS: StakingTri[] = [
     apr2:0,
     chefVersion: ChefVersions.V1,
     doubleRewards: false,
-    inStaging: false
+    inStaging: false,
+    doubleRewardToken: dummyToken
   }
 ]
 
@@ -127,7 +130,8 @@ const AURORA_POOLS: StakingTri[] = [
     apr2: 0,
     chefVersion: ChefVersions.V1,
     doubleRewards: false,
-    inStaging: false
+    inStaging: false,
+    doubleRewardToken: dummyToken
   },
   {
     ID: 1,
@@ -149,7 +153,8 @@ const AURORA_POOLS: StakingTri[] = [
     apr2: 0,
     chefVersion: ChefVersions.V1,
     doubleRewards: false,
-    inStaging: false
+    inStaging: false,
+    doubleRewardToken: dummyToken
   },
   {
     ID: 2,
@@ -171,7 +176,8 @@ const AURORA_POOLS: StakingTri[] = [
     apr2: 0,
     chefVersion: ChefVersions.V1,
     doubleRewards: false,
-    inStaging: false
+    inStaging: false,
+    doubleRewardToken: dummyToken
   },
   {
     ID: 3,
@@ -193,7 +199,8 @@ const AURORA_POOLS: StakingTri[] = [
     apr2: 0,
     chefVersion: ChefVersions.V1,
     doubleRewards: false,
-    inStaging: false
+    inStaging: false,
+    doubleRewardToken: dummyToken
   },
   {
     ID: 4,
@@ -215,7 +222,8 @@ const AURORA_POOLS: StakingTri[] = [
     apr2: 0,
     chefVersion: ChefVersions.V1,
     doubleRewards: false,
-    inStaging: false
+    inStaging: false,
+    doubleRewardToken: dummyToken
   },
   {
     ID: 5,
@@ -237,7 +245,8 @@ const AURORA_POOLS: StakingTri[] = [
     apr2: 0,
     chefVersion: ChefVersions.V1,
     doubleRewards: false,
-    inStaging: false
+    inStaging: false,
+    doubleRewardToken: dummyToken
   },
   {
     ID: 6,
@@ -259,7 +268,8 @@ const AURORA_POOLS: StakingTri[] = [
     apr2: 0,
     chefVersion: ChefVersions.V1,
     doubleRewards: false,
-    inStaging: false
+    inStaging: false,
+    doubleRewardToken: dummyToken
   },
   {
     ID: 7,
@@ -281,7 +291,8 @@ const AURORA_POOLS: StakingTri[] = [
     apr2: 0,
     chefVersion: ChefVersions.V2,
     doubleRewards: true,
-    inStaging: false
+    inStaging: false,
+    doubleRewardToken: AURORA[ChainId.AURORA]
   },
   {
     ID: 8,
@@ -303,7 +314,8 @@ const AURORA_POOLS: StakingTri[] = [
     apr2: 0,
     chefVersion: ChefVersions.V2,
     doubleRewards: true,
-    inStaging: false
+    inStaging: false,
+    doubleRewardToken: AURORA[ChainId.AURORA]
   },
   {
     ID: 9,
@@ -324,8 +336,9 @@ const AURORA_POOLS: StakingTri[] = [
     apr: 0,
     apr2: 0,
     chefVersion: ChefVersions.V2,
-    doubleRewards: false,
-    inStaging: false
+    doubleRewards: true,
+    inStaging: false,
+    doubleRewardToken: LUNA[ChainId.AURORA]
   },
   {
     ID: 10,
@@ -346,8 +359,9 @@ const AURORA_POOLS: StakingTri[] = [
     apr: 0,
     apr2: 0,
     chefVersion: ChefVersions.V2,
-    doubleRewards: false,
-    inStaging: false
+    doubleRewards: true,
+    inStaging: false,
+    doubleRewardToken: LUNA[ChainId.AURORA]
   },
   {
     ID: 11,
@@ -369,7 +383,8 @@ const AURORA_POOLS: StakingTri[] = [
     apr2: 0,
     chefVersion: ChefVersions.V2,
     doubleRewards: false,
-    inStaging: false
+    inStaging: false,
+    doubleRewardToken: dummyToken
   },
   {
     ID: 12,
@@ -391,7 +406,8 @@ const AURORA_POOLS: StakingTri[] = [
     apr2: 0,
     chefVersion: ChefVersions.V2,
     doubleRewards: false,
-    inStaging: false
+    inStaging: false,
+    doubleRewardToken: dummyToken
   },
   {
     ID: 13,
@@ -413,7 +429,8 @@ const AURORA_POOLS: StakingTri[] = [
     apr2: 0,
     chefVersion: ChefVersions.V2,
     doubleRewards: false,
-    inStaging: false
+    inStaging: false,
+    doubleRewardToken: dummyToken
   },
   {
     ID: 14,
@@ -435,7 +452,8 @@ const AURORA_POOLS: StakingTri[] = [
     apr2: 0,
     chefVersion: ChefVersions.V2,
     doubleRewards: false,
-    inStaging: false
+    inStaging: false,
+    doubleRewardToken: dummyToken
   }
 ]
 
@@ -464,7 +482,8 @@ const NULL_POOLS: StakingTri[] = [
     apr2: 0,
     chefVersion: ChefVersions.V1,
     doubleRewards: false,
-    inStaging: false
+    inStaging: false,
+    doubleRewardToken: dummyToken
   }
 ]
 

--- a/src/state/stake/useFarmsAPI.ts
+++ b/src/state/stake/useFarmsAPI.ts
@@ -49,6 +49,7 @@ export function useFarmsAPI(): StakingTriFarms[] {
             chefVersion: chefVersion,
             doubleRewards: activeFarms[index].doubleRewards,
             inStaging: activeFarms[index].inStaging,
+            doubleRewardToken: activeFarms[index].doubleRewardToken
         }
     });
 


### PR DESCRIPTION
- Added `doubleRewardToken` to stake-constants and propagated to FE

- Correct pools with names in dual reward area
![Screen Shot 2022-01-12 at 11 41 47 PM](https://user-images.githubusercontent.com/89817711/149267266-fc4a5dc7-b7c1-40fb-a5b2-f020165a557b.png)




- All the modals and manage page updated with correct token name
![Screen Shot 2022-01-12 at 11 40 06 PM](https://user-images.githubusercontent.com/89817711/149267162-b8d53a68-dc3e-400b-94c3-81980b6e380c.png)
![Screen Shot 2022-01-12 at 11 38 48 PM](https://user-images.githubusercontent.com/89817711/149267167-ad28b209-c281-4c3f-bfcd-8196257a56f9.png)
![Screen Shot 2022-01-12 at 11 37 01 PM](https://user-images.githubusercontent.com/89817711/149267172-851686bc-bcfd-48df-84e1-0593cc2952f9.png)


 