### PR TITLE
Updated .gitignore; Updated Aurora RPC url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.env
+.env.production
 
 /.netlify
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -358,7 +358,7 @@ export const CHAIN_PARAMS = {
       symbol: 'ETH',
       decimals: 18
     },
-    rpcUrls: ['https://mainnet.aurora.dev/Fon6fPMs5rCdJc4mxX4kiSK1vsKdzc3D8k6UF8aruek'],
+    rpcUrls: ['https://mainnet.aurora.dev'],
     blockExplorerUrls: ['https://explorer.mainnet.aurora.dev/']
   }
 }


### PR DESCRIPTION
- Added `.env` and `.env.production` to `.gitignore`
  - These are used in `activateNetwork` here: https://github.com/trisolaris-labs/interface/blob/main/src/components/Web3ReactManager/index.tsx#L30-L35
- Removed API key from rpcUrls
  - This is used for adding a network to a user's metamask, if they don't already have Aurora Mainnet


## Tested adding Aurora to Metamask
<img width="1575" alt="Screen Shot 2022-01-13 at 2 56 02 PM" src="https://user-images.githubusercontent.com/94581898/149421889-a66375d7-2cda-4264-b3e5-bbb77bfcb13b.png">
