### PR TITLE
Disables deposits for legacy pools

### DIFF
--- a/src/components/earn/PoolCardTri.tsx
+++ b/src/components/earn/PoolCardTri.tsx
@@ -60,6 +60,7 @@ type Props = {
     doubleRewards: boolean
     chefVersion: ChefVersions
     inStaging: boolean
+    isLegacy?: boolean
     isPeriodFinished: boolean
     stakedAmount: TokenAmount | null
     token0: Token
@@ -92,6 +93,7 @@ export default function PoolCardTRI({
     chefVersion,
     doubleRewards,
     inStaging,
+    isLegacy,
     isPeriodFinished,
     stakedAmount,
     token0: _token0,
@@ -124,15 +126,21 @@ export default function PoolCardTRI({
                         {currency0.symbol}-{currency1.symbol}
                     </ResponsiveCurrencyLabel>
                 </PairContainer>
-                <Button
-                    disabled={(isStaking || !isPeriodFinished) === false}
-                    isStaking={isStaking}
-                    onClick={() => {
-                        history.push(`/tri/${currencyId(currency0)}/${currencyId(currency1)}/${version}`)
-                    }}
-                >
-                    {isStaking ? t('earn.manage') : t('earn.deposit')}
-                </Button>
+                {isLegacy && !isStaking
+                    ? (
+                        <Button disabled={true} isStaking={isStaking}>{t('earn.deposit')}</Button>
+                    )
+                    : (
+                        <Button
+                            disabled={(isStaking || !isPeriodFinished) === false}
+                            isStaking={isStaking}
+                            onClick={() => {
+                                history.push(`/tri/${currencyId(currency0)}/${currencyId(currency1)}/${version}`)
+                            }}
+                        >
+                            {isStaking ? t('earn.manage') : t('earn.deposit')}
+                        </Button>
+                    )}
             </AutoRow>
 
             <RowBetween>

--- a/src/pages/EarnTri/index.tsx
+++ b/src/pages/EarnTri/index.tsx
@@ -169,6 +169,7 @@ export default function Earn({
               apr={farm.apr}
               apr2={farm.apr2}
               chefVersion={farm.chefVersion}
+              isLegacy={true}
               isPeriodFinished={farm.isPeriodFinished}
               stakedAmount={farm.stakedAmount}
               token0={farm.tokens[0]}


### PR DESCRIPTION
Disabled `deposit` button for legacy pools:

![image](https://user-images.githubusercontent.com/94581898/149582926-c96b6490-b55c-489d-beaa-a5938d0fe91d.png)


If user has already deposited, it will still show manage:
![image](https://user-images.githubusercontent.com/94581898/149583087-1286e000-90cf-4cfc-95eb-a05ca19a99f3.png)
