### PR TITLE
B/perf separate mm vs network

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,6 +7,7 @@ import IUniswapV2Router02_ABI from '../constants/abis/polygon/IUniswapV2Router02
 import { ETHERSCAN_PREFIXES } from '../constants/index'
 import { ChainId, JSBI, Percent, Token, CurrencyAmount, Currency, CETH, ROUTER_ADDRESS } from '@trisolaris/sdk'
 import { TokenAddressMap } from '../state/lists/hooks'
+import { getNetworkLibrary } from '../connectors'
 
 // returns the checksummed address if the address is valid, otherwise returns false
 export function isAddress(value: any): string | false {
@@ -77,7 +78,7 @@ export function getSigner(library: Web3Provider, account: string): JsonRpcSigner
 
 // account is optional
 export function getProviderOrSigner(library: Web3Provider, account?: string): Web3Provider | JsonRpcSigner {
-  return account ? getSigner(library, account) : library
+  return account ? getSigner(library, account) : getNetworkLibrary()
 }
 
 // account is optional


### PR DESCRIPTION
- block updates are sourced from `network` instead of the injected provider
- contracts are now loaded from the network by default; only loading from injected provider if a signer is requested
  - eg [on this line](https://github.com/trisolaris-labs/interface/blob/main/src/hooks/useContract.ts#L75), the last param indicates a signer is _not_ required for this call

Tested swap, add/remove liquidity, stake, and claim on local