### PR TITLE
B/stnear link header fix

### DIFF
--- a/src/components/BridgesMenu/BridgesMenu.styles.tsx
+++ b/src/components/BridgesMenu/BridgesMenu.styles.tsx
@@ -57,7 +57,19 @@ export const MenuButton = styled(ButtonDropdown)`
     color: ${({ theme }) => darken(0.1, theme.text1)};
     box-shadow: none;
   }
-  margin: 0px 4px;
+
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+  svg{
+    width:1.25rem;
+  }
+`}
+
+  ${({ theme }) => theme.mediaWidth.upToXxSmall`
+  margin: 0px 2px;
+  svg{
+    width:1rem;
+  }
+`}
 `
 
 export const StyledArrow = styled.span`

--- a/src/components/BridgesMenu/BridgesMenu.styles.tsx
+++ b/src/components/BridgesMenu/BridgesMenu.styles.tsx
@@ -46,6 +46,7 @@ export const StyledExternalLink = styled(ExternalLink).attrs({
 `
 
 export const MenuButton = styled(ButtonDropdown)`
+  border: 0px;
   padding: 0px;
   background: transparent;
   text-decoration: none;
@@ -60,12 +61,11 @@ export const MenuButton = styled(ButtonDropdown)`
 
   ${({ theme }) => theme.mediaWidth.upToExtraSmall`
   svg{
-    width:1.25rem;
+    display:none;
   }
 `}
 
   ${({ theme }) => theme.mediaWidth.upToXxSmall`
-  margin: 0px 2px;
   svg{
     width:1rem;
   }
@@ -75,10 +75,4 @@ export const MenuButton = styled(ButtonDropdown)`
 export const StyledArrow = styled.span`
   font-size: 11px;
   margin-left: 0.3rem;
-`
-
-export const StyledButtonText = styled.span`
-  ${({ theme }) => theme.mediaWidth.upToXxxSmall`
-    display: none;
-  `}
 `

--- a/src/components/BridgesMenu/index.tsx
+++ b/src/components/BridgesMenu/index.tsx
@@ -6,20 +6,20 @@ import { useModalOpen, useToggleModal } from '../../state/application/hooks'
 import { ApplicationModal } from '../../state/application/actions'
 import { useOnClickOutside } from '../../hooks/useOnClickOutside'
 
-import { StyledMenuFlyout, StyledExternalLink, MenuButton, StyledArrow, StyledButtonText } from './BridgesMenu.styles'
+import { StyledMenuFlyout, StyledExternalLink, MenuButton, StyledArrow } from './BridgesMenu.styles'
 
 import { BRIDGES } from './BridgesMenu.constants'
 
-export default function BridgesMenu() {
+export default function BridgesMenu({...rest}) {
   const node = useRef<HTMLDivElement>()
   const open = useModalOpen(ApplicationModal.BRIDGES_MENU)
   const toggle = useToggleModal(ApplicationModal.BRIDGES_MENU)
   useOnClickOutside(node, open ? toggle : undefined)
 
   return (
-    <StyledMenu ref={node as any}>
+    <StyledMenu ref={node as any} {...rest}>
       <MenuButton onClick={toggle}>
-        <StyledButtonText>Bridges</StyledButtonText>
+        <span>Bridges</span>
       </MenuButton>
 
       {open && (

--- a/src/components/GovernanceMenu/index.tsx
+++ b/src/components/GovernanceMenu/index.tsx
@@ -6,20 +6,20 @@ import { useModalOpen, useToggleModal } from '../../state/application/hooks'
 import { ApplicationModal } from '../../state/application/actions'
 import { useOnClickOutside } from '../../hooks/useOnClickOutside'
 
-import { StyledMenuFlyout, StyledExternalLink, MenuButton, StyledArrow, StyledButtonText } from '../BridgesMenu/BridgesMenu.styles'
+import { StyledMenuFlyout, StyledExternalLink, MenuButton, StyledArrow } from '../BridgesMenu/BridgesMenu.styles'
 
 import { GOVERNANCE } from './GovernanceMenu.constants'
 
-export default function GovernanceMenu() {
+export default function GovernanceMenu({...rest}) {
   const node = useRef<HTMLDivElement>()
   const open = useModalOpen(ApplicationModal.GOVERNANCE_MENU)
   const toggle = useToggleModal(ApplicationModal.GOVERNANCE_MENU)
   useOnClickOutside(node, open ? toggle : undefined)
 
   return (
-    <StyledMenu ref={node as any}>
+    <StyledMenu ref={node as any} {...rest}>
       <MenuButton onClick={toggle}>
-        <StyledButtonText>Governance</StyledButtonText>
+        <span>Governance</span>
       </MenuButton>
 
       {open && (

--- a/src/components/Header/Header.styles.tsx
+++ b/src/components/Header/Header.styles.tsx
@@ -1,0 +1,221 @@
+import { NavLink } from 'react-router-dom'
+import styled from 'styled-components'
+import { darken } from 'polished'
+
+import { ButtonSecondary } from '../Button'
+import Row, { RowFixed } from '../Row'
+
+export const HeaderFrame = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 120px;
+  align-items: center;
+  justify-content: space-between;
+  align-items: center;
+  flex-direction: row;
+  width: 100%;
+  top: 0;
+  position: relative;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  padding: 1rem 1.5rem 1rem 1rem;
+  z-index: 2;
+
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+  grid-template-columns: 1fr;
+  padding: 0 1rem;
+  width: calc(100%);
+  position: relative;
+`};
+
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+      padding: 0.5rem 1rem;
+`}
+`
+
+export const HeaderControls = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-self: flex-end;
+
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+  flex-direction: row;
+  justify-content: space-between;
+  justify-self: center;
+  width: 100%;
+  max-width: 960px;
+  padding: 1rem;
+  position: fixed;
+  bottom: 0px;
+  left: 0px;
+  width: 100%;
+  z-index: 99;
+  height: 72px;
+  border-radius: 12px 12px 0 0;
+  background-color: ${({ theme }) => theme.bg1};
+`};
+`
+
+export const HeaderElement = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+ flex-direction: row-reverse;
+  align-items: center;
+`};
+`
+
+export const HeaderElementWrap = styled.div`
+  display: flex;
+  align-items: center;
+`
+
+export const HeaderRow = styled(RowFixed)`
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+ width: 100%;
+`};
+`
+
+export const HeaderLinks = styled(Row)`
+  justify-content: center;
+
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+  padding: 1rem 0 1rem 1rem;
+  justify-content: flex-end;
+`};
+
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+  padding: 1rem 0;
+  justify-content: center;
+  font-size: 0.85rem;
+`}
+
+  ${({ theme }) => theme.mediaWidth.upToXxSmall`
+font-size: 0.8rem;
+`}
+`
+
+export const AccountElement = styled.div<{ active: boolean }>`
+display: flex;
+flex-direction: row;
+align-items: center;
+border-radius: 12px;
+white-space: nowrap;
+width: 100%;
+cursor: pointer;
+
+:focus {
+  border: 1px solid blue;
+}
+/* :hover {
+  background-color: ${({ theme, active }) => (!active ? theme.bg2 : theme.bg4)};
+} */
+`
+
+export const TRIButton = styled(ButtonSecondary)`
+color: white;
+padding: 4px 8px;
+height: 36px;
+font-weight: 500;
+border: none;
+background: ${({ theme }) => theme.primary1}
+&:hover, &:focus, &:active {
+  border: none;
+  box-shadow: none;
+  background: ${({ theme }) => darken(0.12, theme.primary1)}
+}
+`
+
+export const TRIWrapper = styled(AccountElement)`
+  color: white;
+  padding: 4px 0;
+  height: 36px;
+  font-weight: 500;
+`
+
+export const Title = styled(NavLink)`
+  display: flex;
+  align-items: center;
+  pointer-events: auto;
+  justify-self: flex-start;
+  margin-right: 12px;
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+  justify-self: center;
+`};
+  :hover {
+    cursor: pointer;
+  }
+`
+
+export const TRIIcon = styled.div`
+  transition: transform 0.3s ease;
+  :hover {
+    transform: rotate(-5deg);
+  }
+`
+
+export const activeClassName = 'ACTIVE'
+
+export const StyledNavLink = styled(NavLink).attrs({
+  activeClassName
+})`
+  ${({ theme }) => theme.flexRowNoWrap}
+  align-items: left;
+  border-radius: 3rem;
+  outline: none;
+  cursor: pointer;
+  text-decoration: none;
+  color: ${({ theme }) => theme.text2};
+  font-size: 1rem;
+  width: fit-content;
+  margin: 0 12px;
+  font-weight: 500;
+
+  &.${activeClassName} {
+    border-radius: 12px;
+    font-weight: 600;
+    color: ${({ theme }) => theme.text1};
+  }
+
+  :hover,
+  :focus {
+    color: ${({ theme }) => darken(0.1, theme.text1)};
+  }
+
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+  margin: 0 5px;
+  font-size: 0.85rem;
+`}
+
+  ${({ theme }) => theme.mediaWidth.upToXxSmall`
+  margin: 0 4px;
+  font-size: 0.8rem;
+`}
+`
+
+export const IconWrapper = styled.div<{ size?: number }>`
+  ${({ theme }) => theme.flexColumnNoWrap};
+  align-items: center;
+  justify-content: center;
+  & > * {
+    height: ${({ size }) => (size ? size + 'px' : '32px')};
+    width: ${({ size }) => (size ? size + 'px' : '32px')};
+  }
+`
+
+export const StyledHomeNavLink = styled(StyledNavLink)`
+  margin: 0 0 0 0.25rem;
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+  display:none;
+`};
+`
+
+export const HomeContainer = styled.div`
+  display: flex;
+  align-items: center;
+  margin-right: 2rem;
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+  margin-right:0;
+`};
+`

--- a/src/components/Header/Header.styles.tsx
+++ b/src/components/Header/Header.styles.tsx
@@ -1,9 +1,27 @@
 import { NavLink } from 'react-router-dom'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { darken } from 'polished'
 
 import { ButtonSecondary } from '../Button'
 import Row, { RowFixed } from '../Row'
+import BridgesMenu from '../BridgesMenu'
+import GovernanceMenu from '../GovernanceMenu'
+
+const responsiveTextAndMargin = css`
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+margin: 0 5px;
+font-size: 0.925rem;
+`};
+
+  ${({ theme }) => theme.mediaWidth.upToXxSmall`
+margin: 0 4px;
+font-size: 0.85rem;
+`};
+
+  ${({ theme }) => theme.mediaWidth.upToXxxSmall`
+font-size: 0.75rem;
+`};
+`
 
 export const HeaderFrame = styled.div`
   display: grid;
@@ -88,11 +106,6 @@ export const HeaderLinks = styled(Row)`
   ${({ theme }) => theme.mediaWidth.upToExtraSmall`
   padding: 1rem 0;
   justify-content: center;
-  font-size: 0.85rem;
-`}
-
-  ${({ theme }) => theme.mediaWidth.upToXxSmall`
-font-size: 0.8rem;
 `}
 `
 
@@ -182,16 +195,7 @@ export const StyledNavLink = styled(NavLink).attrs({
   :focus {
     color: ${({ theme }) => darken(0.1, theme.text1)};
   }
-
-  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
-  margin: 0 5px;
-  font-size: 0.85rem;
-`}
-
-  ${({ theme }) => theme.mediaWidth.upToXxSmall`
-  margin: 0 4px;
-  font-size: 0.8rem;
-`}
+  ${responsiveTextAndMargin};
 `
 
 export const IconWrapper = styled.div<{ size?: number }>`
@@ -218,4 +222,12 @@ export const HomeContainer = styled.div`
   ${({ theme }) => theme.mediaWidth.upToExtraSmall`
   margin-right:0;
 `};
+`
+
+export const StyledBridgesMenu = styled(BridgesMenu)`
+  ${responsiveTextAndMargin};
+`
+
+export const StyledGovernanceMenu = styled(GovernanceMenu)`
+  ${responsiveTextAndMargin};
 `

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -6,8 +6,6 @@ import LogoDark from '../../assets/svg/planets.svg'
 import Menu from '../Menu'
 import TriPriceModal from '../TriPriceModal'
 import Web3Status from '../Web3Status'
-import BridgesMenu from '../BridgesMenu'
-import GovernanceMenu from '../GovernanceMenu'
 
 import { useActiveWeb3React } from '../../hooks'
 
@@ -30,6 +28,8 @@ import {
   IconWrapper,
   StyledHomeNavLink,
   HomeContainer,
+  StyledBridgesMenu,
+  StyledGovernanceMenu
 } from './Header.styles'
 
 export default function Header() {
@@ -80,8 +80,8 @@ export default function Header() {
           >
             {t('header.farm')}
           </StyledNavLink>
-          <BridgesMenu />
-          <GovernanceMenu />
+          <StyledBridgesMenu />
+          <StyledGovernanceMenu />
         </HeaderLinks>
       </HeaderRow>
       <HeaderControls>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,247 +1,36 @@
 import React from 'react'
 import { Text } from 'rebass'
-import { NavLink } from 'react-router-dom'
-import { darken, lighten } from 'polished'
 import { useTranslation } from 'react-i18next'
 
-import styled from 'styled-components'
-
 import LogoDark from '../../assets/svg/planets.svg'
-import { useActiveWeb3React } from '../../hooks'
-import { ButtonSecondary } from '../Button'
-
-import { RedCard } from '../Card'
 import Menu from '../Menu'
+import TriPriceModal from '../TriPriceModal'
+import Web3Status from '../Web3Status'
 import BridgesMenu from '../BridgesMenu'
 import GovernanceMenu from '../GovernanceMenu'
 
-import Row, { RowFixed } from '../Row'
-import Web3Status from '../Web3Status'
+import { useActiveWeb3React } from '../../hooks'
+
 import useTriPrice from '../../hooks/useTriPrice'
 import { useToggleTriPriceModal } from '../../state/application/hooks'
-import TriPriceModal from '../TriPriceModal'
 
-const HeaderFrame = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 120px;
-  align-items: center;
-  justify-content: space-between;
-  align-items: center;
-  flex-direction: row;
-  width: 100%;
-  top: 0;
-  position: relative;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-  padding: 1rem 1.5rem 1rem 1rem;
-  z-index: 2;
-
-  ${({ theme }) => theme.mediaWidth.upToMedium`
-    grid-template-columns: 1fr;
-    padding: 0 1rem;
-    width: calc(100%);
-    position: relative;
-  `};
-
-  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
-        padding: 0.5rem 1rem;
-  `}
-`
-
-const HeaderControls = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-self: flex-end;
-
-  ${({ theme }) => theme.mediaWidth.upToMedium`
-    flex-direction: row;
-    justify-content: space-between;
-    justify-self: center;
-    width: 100%;
-    max-width: 960px;
-    padding: 1rem;
-    position: fixed;
-    bottom: 0px;
-    left: 0px;
-    width: 100%;
-    z-index: 99;
-    height: 72px;
-    border-radius: 12px 12px 0 0;
-    background-color: ${({ theme }) => theme.bg1};
-  `};
-`
-
-const HeaderElement = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-
-  ${({ theme }) => theme.mediaWidth.upToMedium`
-   flex-direction: row-reverse;
-    align-items: center;
-  `};
-`
-
-const HeaderElementWrap = styled.div`
-  display: flex;
-  align-items: center;
-`
-
-const HeaderRow = styled(RowFixed)`
-  ${({ theme }) => theme.mediaWidth.upToMedium`
-   width: 100%;
-  `};
-`
-
-const HeaderLinks = styled(Row)`
-  justify-content: center;
-
-  ${({ theme }) => theme.mediaWidth.upToMedium`
-    padding: 1rem 0 1rem 1rem;
-    justify-content: flex-end;
-`};
-  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
-    padding: 1rem 0;
-    justify-content: center;
-`};
-`
-
-const AccountElement = styled.div<{ active: boolean }>`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  border-radius: 12px;
-  white-space: nowrap;
-  width: 100%;
-  cursor: pointer;
-
-  :focus {
-    border: 1px solid blue;
-  }
-  /* :hover {
-    background-color: ${({ theme, active }) => (!active ? theme.bg2 : theme.bg4)};
-  } */
-`
-
-const TRIButton = styled(ButtonSecondary)`
-  color: white;
-  padding: 4px 8px;
-  height: 36px;
-  font-weight: 500;
-  border: none;
-  background: ${({ theme }) => theme.primary1}
-  &:hover, &:focus, &:active {
-    border: none;
-    box-shadow: none;
-    background: ${({ theme }) => darken(0.12, theme.primary1)}
-  }
-`
-
-const TRIWrapper = styled(AccountElement)`
-  color: white;
-  padding: 4px 0;
-  height: 36px;
-  font-weight: 500;
-`
-
-const HideSmall = styled.span`
-  ${({ theme }) => theme.mediaWidth.upToSmall`
-    display: none;
-  `};
-`
-
-const NetworkCard = styled(RedCard)`
-  border-radius: 12px;
-  padding: 8px 12px;
-  ${({ theme }) => theme.mediaWidth.upToSmall`
-    margin: 0;
-    margin-right: 0.5rem;
-    width: initial;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    flex-shrink: 1;
-  `};
-`
-
-const Title = styled(NavLink)`
-  display: flex;
-  align-items: center;
-  pointer-events: auto;
-  justify-self: flex-start;
-  margin-right: 12px;
-  ${({ theme }) => theme.mediaWidth.upToSmall`
-    justify-self: center;
-  `};
-  :hover {
-    cursor: pointer;
-  }
-`
-
-const TRIIcon = styled.div`
-  transition: transform 0.3s ease;
-  :hover {
-    transform: rotate(-5deg);
-  }
-`
-
-const activeClassName = 'ACTIVE'
-
-const StyledNavLink = styled(NavLink).attrs({
-  activeClassName
-})`
-  ${({ theme }) => theme.flexRowNoWrap}
-  align-items: left;
-  border-radius: 3rem;
-  outline: none;
-  cursor: pointer;
-  text-decoration: none;
-  color: ${({ theme }) => theme.text2};
-  font-size: 1rem;
-  width: fit-content;
-  margin: 0 12px;
-  font-weight: 500;
-
-  &.${activeClassName} {
-    border-radius: 12px;
-    font-weight: 600;
-    color: ${({ theme }) => theme.text1};
-  }
-
-  :hover,
-  :focus {
-    color: ${({ theme }) => darken(0.1, theme.text1)};
-  }
-
-  ${({ theme }) => theme.mediaWidth.upToXxSmall`
-    margin: 0 6px;
-  `}
-`
-
-const IconWrapper = styled.div<{ size?: number }>`
-  ${({ theme }) => theme.flexColumnNoWrap};
-  align-items: center;
-  justify-content: center;
-  & > * {
-    height: ${({ size }) => (size ? size + 'px' : '32px')};
-    width: ${({ size }) => (size ? size + 'px' : '32px')};
-  }
-`
-
-const StyledHomeNavLink = styled(StyledNavLink)`
-  margin: 0 0 0 0.25rem;
-  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
-    display:none;
-  `};
-`
-
-const HomeContainer = styled.div`
-  display: flex;
-  align-items: center;
-  margin-right: 2rem;
-  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
-    margin-right:0;
-  `};
-`
+import {
+  HeaderFrame,
+  HeaderControls,
+  HeaderElement,
+  HeaderElementWrap,
+  HeaderRow,
+  HeaderLinks,
+  AccountElement,
+  TRIButton,
+  TRIWrapper,
+  Title,
+  TRIIcon,
+  StyledNavLink,
+  IconWrapper,
+  StyledHomeNavLink,
+  HomeContainer,
+} from './Header.styles'
 
 export default function Header() {
   const { account } = useActiveWeb3React()

--- a/src/components/StyledMenu/index.tsx
+++ b/src/components/StyledMenu/index.tsx
@@ -28,7 +28,6 @@ export const StyledMenuButton = styled.button`
 `
 
 export const StyledMenu = styled.div`
-  margin-left: 0.5rem;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/components/earn/PoolCardTri.styles.tsx
+++ b/src/components/earn/PoolCardTri.styles.tsx
@@ -79,23 +79,22 @@ export const TokenPairBackgroundColor = styled.span<{ bgColor1: string | null; b
 
 export const StyledExternalLink = styled(ExternalLink)`
   z-index: 1;
-  text-decoration: none;
+  text-decoration: underline;
   color: ${({ theme }) => theme.text2};
-  font-weight: 700;
+  font-weight: 400;
   font-size: 0.75rem;
+  margin: 0;
+  position: absolute;
+  top: 7px;
+  left: 70px;
+
   :hover,
   :focus {
     text-decoration: none;
     color: ${({ theme }) => darken(0.1, theme.text1)};
   }
-`
 
-export const StyledHeading = styled.span`
-  margin: 0;
-  color: ${({ theme }) => theme.text2};
-  position: absolute;
-  top: 7px;
-  left: 70px;
-  font-size: 0.75rem;
-  font-weight: 500;
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+  left:60px;
+`};
 `

--- a/src/components/earn/PoolCardTri.styles.tsx
+++ b/src/components/earn/PoolCardTri.styles.tsx
@@ -1,9 +1,10 @@
 import styled from 'styled-components'
-import { lighten } from 'polished'
+import { lighten, darken } from 'polished'
 
 import { TYPE } from '../../theme'
 import Card from '../Card'
 import { ButtonPrimary } from '../Button'
+import { ExternalLink } from '../../theme'
 
 export const Wrapper = styled(Card)<{ bgColor1: string | null; bgColor2?: string | null; isDoubleRewards: boolean }>`
   border: ${({ isDoubleRewards, theme }) =>
@@ -19,7 +20,7 @@ export const Wrapper = styled(Card)<{ bgColor1: string | null; bgColor2?: string
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
       grid-template-rows: auto 1fr;
-      padding: .75rem;
+      padding: 1.1rem .75rem;
 `};
 `
 
@@ -74,4 +75,27 @@ export const TokenPairBackgroundColor = styled.span<{ bgColor1: string | null; b
   top: 0;
   left: 0;
   user-select: none;
+`
+
+export const StyledExternalLink = styled(ExternalLink)`
+  z-index: 1;
+  text-decoration: none;
+  color: ${({ theme }) => theme.text2};
+  font-weight: 700;
+  font-size: 0.75rem;
+  :hover,
+  :focus {
+    text-decoration: none;
+    color: ${({ theme }) => darken(0.1, theme.text1)};
+  }
+`
+
+export const StyledHeading = styled.span`
+  margin: 0;
+  color: ${({ theme }) => theme.text2};
+  position: absolute;
+  top: 7px;
+  left: 70px;
+  font-size: 0.75rem;
+  font-weight: 500;
 `

--- a/src/components/earn/PoolCardTri.tsx
+++ b/src/components/earn/PoolCardTri.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react'
-import { Token } from '@trisolaris/sdk'
+import { Token, ChainId } from '@trisolaris/sdk'
 import { useTranslation } from 'react-i18next'
 import { useHistory } from 'react-router-dom'
+import { Settings2 as ManageIcon } from 'lucide-react'
 
 import { TYPE } from '../../theme'
 import { AutoColumn } from '../Column'
@@ -17,8 +18,7 @@ import { currencyId } from '../../utils/currencyId'
 import { addCommasToNumber } from '../../utils'
 import { getPairRenderOrder, isTokenAmountPositive } from '../../utils/pools'
 
-import { BIG_INT_ZERO } from '../../constants'
-import { Settings2 as ManageIcon } from 'lucide-react'
+import { STNEAR } from '../../constants/tokens'
 
 import {
   Wrapper,
@@ -26,7 +26,9 @@ import {
   ResponsiveCurrencyLabel,
   TokenPairBackgroundColor,
   StyledActionsContainer,
-  Button
+  Button,
+  StyledExternalLink,
+  StyledHeading
 } from './PoolCardTri.styles'
 
 type PoolCardTriProps = {
@@ -45,6 +47,8 @@ type PoolCardTriProps = {
   isStaking: boolean
   version: number
 }
+
+const stNearToken = STNEAR[ChainId.AURORA]
 
 const DefaultPoolCardtri = ({
   apr,
@@ -101,8 +105,12 @@ const DefaultPoolCardtri = ({
   return (
     <Wrapper bgColor1={backgroundColor1} bgColor2={backgroundColor2} isDoubleRewards={doubleRewards}>
       <TokenPairBackgroundColor bgColor1={backgroundColor1} bgColor2={backgroundColor2} />
+
       <AutoRow justifyContent="space-between">
         <PairContainer>
+          {(token0 === stNearToken || token1 === stNearToken) && (
+            <StyledHeading>Get stNEAR <StyledExternalLink href="https://metapool.app/">Here</StyledExternalLink></StyledHeading>
+          )}
           <DoubleCurrencyLogo currency0={currency0} currency1={currency1} size={20} />
           <ResponsiveCurrencyLabel>
             {currency0.symbol}-{currency1.symbol}
@@ -123,7 +131,6 @@ const DefaultPoolCardtri = ({
           </StyledActionsContainer>
         )}
       </AutoRow>
-
       <RowBetween>
         <AutoColumn>
           <TYPE.mutedSubHeader>{t('earn.totalStaked')}</TYPE.mutedSubHeader>

--- a/src/components/earn/PoolCardTri.tsx
+++ b/src/components/earn/PoolCardTri.tsx
@@ -28,7 +28,6 @@ import {
   StyledActionsContainer,
   Button,
   StyledExternalLink,
-  StyledHeading
 } from './PoolCardTri.styles'
 
 type PoolCardTriProps = {
@@ -109,7 +108,7 @@ const DefaultPoolCardtri = ({
       <AutoRow justifyContent="space-between">
         <PairContainer>
           {(token0 === stNearToken || token1 === stNearToken) && (
-            <StyledHeading>Get stNEAR <StyledExternalLink href="https://metapool.app/">Here</StyledExternalLink></StyledHeading>
+            <StyledExternalLink href="https://metapool.app/">Get stNEAR</StyledExternalLink>
           )}
           <DoubleCurrencyLogo currency0={currency0} currency1={currency1} size={20} />
           <ResponsiveCurrencyLabel>

--- a/src/components/earn/PoolCardTri.tsx
+++ b/src/components/earn/PoolCardTri.tsx
@@ -108,7 +108,7 @@ const DefaultPoolCardtri = ({
       <AutoRow justifyContent="space-between">
         <PairContainer>
           {(token0 === stNearToken || token1 === stNearToken) && (
-            <StyledExternalLink href="https://metapool.app/">Get stNEAR</StyledExternalLink>
+            <StyledExternalLink href="https://metapool.app/">Get stNEAR ↗</StyledExternalLink>
           )}
           <DoubleCurrencyLogo currency0={currency0} currency1={currency1} size={20} />
           <ResponsiveCurrencyLabel>


### PR DESCRIPTION
Fixed overlapping header on mobile + Added stnear heading on relevant pool cards.

Stnear heading
<img width="774" alt="Screen Shot 2022-03-22 at 12 36 13" src="https://user-images.githubusercontent.com/96993065/159521692-e12c4080-f32a-466b-be51-ba93633a484b.png">




fixed header + stnear heading on mobile 
<img width="351" alt="Screen Shot 2022-03-22 at 12 36 19" src="https://user-images.githubusercontent.com/96993065/159520321-20bda773-d4c8-4070-a5a4-f6d4dc56f5f2.png">

