### PR TITLE
Fix get stNEAR link and header menus margins

### DIFF
--- a/src/components/Header/Header.styles.tsx
+++ b/src/components/Header/Header.styles.tsx
@@ -8,6 +8,7 @@ import BridgesMenu from '../BridgesMenu'
 import GovernanceMenu from '../GovernanceMenu'
 
 const responsiveTextAndMargin = css`
+margin: 0 12px;
   ${({ theme }) => theme.mediaWidth.upToExtraSmall`
 margin: 0 5px;
 font-size: 0.925rem;
@@ -182,7 +183,6 @@ export const StyledNavLink = styled(NavLink).attrs({
   color: ${({ theme }) => theme.text2};
   font-size: 1rem;
   width: fit-content;
-  margin: 0 12px;
   font-weight: 500;
 
   &.${activeClassName} {

--- a/src/components/earn/PoolCardTri.tsx
+++ b/src/components/earn/PoolCardTri.tsx
@@ -108,7 +108,7 @@ const DefaultPoolCardtri = ({
       <AutoRow justifyContent="space-between">
         <PairContainer>
           {(token0 === stNearToken || token1 === stNearToken) && (
-            <StyledExternalLink href="https://metapool.app/">Get stNEAR ↗</StyledExternalLink>
+            <StyledExternalLink href="https://metapool.app/dapp/mainnet/metapool-aurora/">Get stNEAR ↗</StyledExternalLink>
           )}
           <DoubleCurrencyLogo currency0={currency0} currency1={currency1} size={20} />
           <ResponsiveCurrencyLabel>


### PR DESCRIPTION
Fixed get stNEAR link, now opens: https://metapool.app/dapp/mainnet/metapool-aurora/

Fixed bridges and governance menu margins

header preview:
<img width="656" alt="Screen Shot 2022-03-23 at 12 39 12" src="https://user-images.githubusercontent.com/96993065/159737945-da1b11ff-0a6f-47d4-9cf6-cad4ed0ba74a.png">


