### PR TITLE
B/ss cards add questionmark helpers

### DIFF
--- a/src/components/ContractAddress/ContractAddress.styles.tsx
+++ b/src/components/ContractAddress/ContractAddress.styles.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 import { darken } from 'polished'
 
 import Tooltip from '../Tooltip'
+import { Text } from 'rebass'
 
 export const StyledAddressContainer = styled.div`
   display: flex;
@@ -34,4 +35,10 @@ export const StyledTooltip = styled(Tooltip)`
   min-width: 190px;
   font-size: 0.75rem;
   text-align: center;
+`
+
+export const StyledText = styled(Text)`
+  font-size: 16px;
+  font-weight: 500;
+  margin-right: 10px;
 `

--- a/src/components/ContractAddress/index.tsx
+++ b/src/components/ContractAddress/index.tsx
@@ -6,10 +6,10 @@ import { Copy, Check } from 'lucide-react'
 import useCopyClipboard from '../../hooks/useCopyClipboard'
 import { shortenAddress } from '../../utils'
 
-import { StyledAddressContainer, StyledContractButton, StyledTooltip } from './ContractAddress.styles'
+import { StyledAddressContainer, StyledContractButton, StyledTooltip, StyledText } from './ContractAddress.styles'
 
-const ContractAddress = ({ token, address }: { token?: Token; address?: string }) => {
-  const addressToShow = (address ?? token?.address) ?? ""
+const ContractAddress = ({ token, address, ...rest }: { token?: Token; address?: string }) => {
+  const addressToShow = address ?? token?.address ?? ''
 
   const [showTooltip, setShowTooltip] = useState(false)
   const [isCopied, setCopied] = useCopyClipboard(750)
@@ -33,15 +33,14 @@ const ContractAddress = ({ token, address }: { token?: Token; address?: string }
   }
 
   return (
-    <StyledAddressContainer>
-      <Text fontSize={16} fontWeight={500} marginRight={'10px'}>
-        {shortenAddress(addressToShow)}
-      </Text>
+    <StyledAddressContainer {...rest}>
+      <StyledText {...rest}>{shortenAddress(addressToShow)}</StyledText>
       <StyledContractButton
         onMouseEnter={handleMouseEnter}
         onBlur={handleMouseLeave}
         onMouseLeave={handleMouseLeave}
         onClick={handleClick}
+        style={{ marginLeft: '10px' }}
       >
         <StyledTooltip text={isCopied ? 'Copied!' : 'Copy address to clipboard'} placement="top" show={showTooltip}>
           {isCopied ? <Check size={14} /> : <Copy size={14} />}

--- a/src/components/PositionCard/StablePositionCard/index.tsx
+++ b/src/components/PositionCard/StablePositionCard/index.tsx
@@ -137,12 +137,6 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
     push(`${pathname}/remove/${name}`)
   }
 
-  const formattedPoolTokenData = stablePoolData.tokens.map(({ token, percent, value }) => ({
-    label: token.name,
-    token,
-    value: `${value.toString()} (${percent.toFixed(2)}%)`
-  }))
-
   const formattedPoolData = [
     {
       label: 'Virtual Price',
@@ -150,18 +144,19 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
       tooltipData: 'Average dollar value of pool token.'
     },
     {
+      label: 'Swap Fee',
+
+      value: stablePoolData.swapFee == null ? '-' : `${stablePoolData.swapFee?.toSignificant(2)}%`
+    },
+    {
+      label: 'Admin Fee',
+      value: stablePoolData.adminFee == null ? '-' : `${stablePoolData.adminFee?.toSignificant(2)}%`
+    },
+    {
       label: 'Amplification coefficient',
       value: stablePoolData.aParameter?.toString() ?? '-',
       tooltipData:
         "Higher values widen the range of low-slippages swaps, while lower values help keep the pool's composition balanced."
-    },
-    {
-      label: 'Swap Fee',
-      value: stablePoolData.swapFee == null ? '-' : `${stablePoolData.swapFee?.toString()}%`
-    },
-    {
-      label: 'Admin Fee',
-      value: stablePoolData.adminFee == null ? '-' : `${stablePoolData.adminFee?.toString()}%`
     }
   ]
 
@@ -232,7 +227,7 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
             </FixedHeightRow>
             <FixedHeightRow>
               <StyledText fontWeight={500}>{stablePoolData.lpToken?.name} LP Token Balance</StyledText>
-              <StyledText fontWeight={500}>{`${userData?.lpTokenBalance.toFixed(3)}`}</StyledText>
+              <StyledText fontWeight={500}>{`$${userData?.lpTokenBalance.toFixed(3)}`}</StyledText>
             </FixedHeightRow>
           </AutoColumn>
         ) : null}
@@ -258,25 +253,7 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
               <TYPE.subHeader fontSize={16} fontWeight={500} marginTop="8px">
                 Pool Info
               </TYPE.subHeader>
-              {formattedPoolData
-                .slice(0, 1)
-                .map(({ label, value, tooltipData }) => renderRow({ label, value, tooltipData }))}
-              <FixedHeightRow>
-                <StyledText>Swap Fee:</StyledText>
-                <StyledText>
-                  {stablePoolData.swapFee == null ? '-' : `${stablePoolData.swapFee?.toSignificant(2)}%`}
-                </StyledText>
-              </FixedHeightRow>
-              <FixedHeightRow>
-                <StyledText>Admin Fee:</StyledText>
-                <StyledText>
-                  {stablePoolData.adminFee == null ? '-' : `${stablePoolData.adminFee?.toSignificant(2)}%`}
-                </StyledText>
-              </FixedHeightRow>
-              <FixedHeightRow>
-                <StyledText>Amplification coefficient:</StyledText>
-                <StyledText>{stablePoolData.aParameter?.toString() ?? '-'}</StyledText>
-              </FixedHeightRow>
+              {formattedPoolData.map(({ label, value, tooltipData }) => renderRow({ label, value, tooltipData }))}
 
               <TYPE.subHeader fontSize={16} fontWeight={500} marginTop="8px">
                 Contracts
@@ -291,24 +268,6 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
                   <ContractAddress address={poolAddress} />
                 </FixedHeightRow>
               </AutoColumn>
-
-              {/* <ButtonRow marginTop="10px"> */}
-              {formattedPoolData.slice(1).map(({ label, value, tooltipData }) => (
-                <FixedHeightRow key={label}>
-                  <div>
-                    <StyledText fontWeight={500}>{label}:</StyledText>
-                    {tooltipData && (
-                      <MouseoverTooltip text={tooltipData}>
-                        <HelpCircle size={16} style={{ zIndex: 10 }} />
-                      </MouseoverTooltip>
-                    )}
-                  </div>
-                  <StyledText fontWeight={500}>{value}</StyledText>
-                </FixedHeightRow>
-              ))}
-              {formattedPoolData
-                .slice(1)
-                .map(({ label, value, tooltipData }) => renderRow({ label, value, tooltipData }))}
             </AutoColumn>
             <AutoColumn gap="8px" style={{ marginTop: '10px' }}>
               <ButtonRow>

--- a/src/components/PositionCard/StablePositionCard/index.tsx
+++ b/src/components/PositionCard/StablePositionCard/index.tsx
@@ -236,7 +236,7 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
                 <FixedHeightRow key={token.name}>
                   <div>
                     <CurrencyLogo size="20px" style={{ marginRight: '8px' }} currency={unwrappedToken(token)} />
-                    {token.name}
+                    {token.name}:
                   </div>
                   <StyledText fontWeight={500} marginLeft={'6px'}>
                     {`${value.toString()} (${percent.toFixed(2)}%)`}

--- a/src/components/PositionCard/StablePositionCard/index.tsx
+++ b/src/components/PositionCard/StablePositionCard/index.tsx
@@ -94,6 +94,13 @@ const StyledColon = styled.span`
   `};
 `
 
+const StyledContractAddress = styled(ContractAddress)`
+  font-size: 16px;
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+font-size: 12px !important;
+`};
+`
+
 interface PositionCardProps {
   pair: Pair
   showUnwrapped?: boolean
@@ -235,7 +242,7 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
         {showMore && (
           <div style={{ marginTop: '20px' }}>
             <AutoColumn gap="8px">
-              <TYPE.subHeader fontSize={16} fontWeight={500}>
+              <TYPE.subHeader fontSize={16} fontWeight={600}>
                 Currency Reserves
               </TYPE.subHeader>
               {stablePoolData.tokens.map(({ token, percent, value }) => (
@@ -250,22 +257,22 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
                 </FixedHeightRow>
               ))}
 
-              <TYPE.subHeader fontSize={16} fontWeight={500} marginTop="8px">
+              <TYPE.subHeader fontSize={16} fontWeight={600} marginTop="8px">
                 Pool Info
               </TYPE.subHeader>
               {formattedPoolData.map(({ label, value, tooltipData }) => renderRow({ label, value, tooltipData }))}
 
-              <TYPE.subHeader fontSize={16} fontWeight={500} marginTop="8px">
+              <TYPE.subHeader fontSize={16} fontWeight={600} marginTop="8px">
                 Contracts
               </TYPE.subHeader>
               <AutoColumn gap="8px">
                 <FixedHeightRow>
-                  <div>{stablePoolData.lpToken?.name} LP Token:</div>
-                  <ContractAddress address={stablePoolData.lpToken?.address} />
+                  <StyledText fontWeight={500}>{stablePoolData.lpToken?.name} LP Token:</StyledText>
+                  <StyledContractAddress address={stablePoolData.lpToken?.address} />
                 </FixedHeightRow>
                 <FixedHeightRow>
-                  <div>{stablePoolData.name} Pool Contract:</div>
-                  <ContractAddress address={poolAddress} />
+                  <StyledText fontWeight={500}>{stablePoolData.name} Pool Contract:</StyledText>
+                  <StyledContractAddress address={poolAddress} />
                 </FixedHeightRow>
               </AutoColumn>
             </AutoColumn>

--- a/src/components/PositionCard/StablePositionCard/index.tsx
+++ b/src/components/PositionCard/StablePositionCard/index.tsx
@@ -174,7 +174,7 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
   const renderRow = ({ label, tooltipData, value }: { label: string; tooltipData?: string; value: string }) => {
     return (
       <FixedHeightRow key={label}>
-        <StyledText fontWeight={500} style={{ zIndex: 1, display: 'flex' }}>
+        <StyledText style={{ zIndex: 1, display: 'flex' }}>
           {`${label}${tooltipData ? '' : ':'}`}
           {tooltipData && (
             <>
@@ -267,11 +267,11 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
               </TYPE.subHeader>
               <AutoColumn gap="8px">
                 <FixedHeightRow>
-                  <StyledText fontWeight={500}>{stablePoolData.lpToken?.name} LP Token:</StyledText>
+                  <StyledText>{stablePoolData.lpToken?.name} LP Token:</StyledText>
                   <StyledContractAddress address={stablePoolData.lpToken?.address} />
                 </FixedHeightRow>
                 <FixedHeightRow>
-                  <StyledText fontWeight={500}>{stablePoolData.name} Pool Contract:</StyledText>
+                  <StyledText>{stablePoolData.name} Pool Contract:</StyledText>
                   <StyledContractAddress address={poolAddress} />
                 </FixedHeightRow>
               </AutoColumn>

--- a/src/components/PositionCard/StablePositionCard/index.tsx
+++ b/src/components/PositionCard/StablePositionCard/index.tsx
@@ -26,6 +26,8 @@ import CurrencyLogo from '../../CurrencyLogo'
 
 import ContractAddress from '../../ContractAddress'
 import { TYPE } from '../../../theme'
+import { HelpCircle } from 'lucide-react'
+import { MouseoverTooltip } from '../../Tooltip'
 
 export const FixedHeightRow = styled(RowBetween)`
   height: 24px;
@@ -67,7 +69,7 @@ font-size: 16px !important;
 `
 
 const StyledFixedHeightRow = styled(FixedHeightRow)`
-  z-index: 99;
+  z-index: 1;
   box-sizing: content-box;
   border: 20px solid transparent;
   margin: -20px;
@@ -113,6 +115,34 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
   function handleRemoveLiquidity() {
     push(`${pathname}/remove/${name}`)
   }
+
+  const formattedPoolTokenData = stablePoolData.tokens.map(({ token, percent, value }) => ({
+    label: token.name,
+    token,
+    value: `${value.toString()} (${percent.toFixed(2)}%)`
+  }))
+
+  const formattedPoolData = [
+    {
+      label: 'Virtual Price',
+      value: stablePoolData.virtualPrice == null ? '-' : `$${stablePoolData.virtualPrice?.toFixed(6)}`,
+      tooltipData: 'Average dollar value of pool token.'
+    },
+    {
+      label: 'Amplification coefficient',
+      value: stablePoolData.aParameter?.toString() ?? '-',
+      tooltipData:
+        "Higher values widen the range of low-slippages swaps, while lower values help keep the pool's composition balanced."
+    },
+    {
+      label: 'Swap Fee',
+      value: stablePoolData.swapFee == null ? '-' : `${stablePoolData.swapFee?.toString()}%`
+    },
+    {
+      label: 'Admin Fee',
+      value: stablePoolData.adminFee == null ? '-' : `${stablePoolData.adminFee?.toString()}%`
+    }
+  ]
 
   const handleCardClick = () => {
     setShowMore(!showMore)
@@ -215,7 +245,23 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
                 </FixedHeightRow>
               </AutoColumn>
 
-              <ButtonRow marginTop="10px">
+              {/* <ButtonRow marginTop="10px"> */}
+              {formattedPoolData.slice(1).map(({ label, value, tooltipData }) => (
+                <FixedHeightRow key={label}>
+                  <div>
+                    <StyledText fontWeight={500}>{label}:</StyledText>
+                    {tooltipData && (
+                      <MouseoverTooltip text={tooltipData}>
+                        <HelpCircle size={16} style={{ zIndex: 10 }} />
+                      </MouseoverTooltip>
+                    )}
+                  </div>
+                  <StyledText fontWeight={500}>{value}</StyledText>
+                </FixedHeightRow>
+              ))}
+            </AutoColumn>
+            <AutoColumn gap="8px" style={{ marginTop: '10px' }}>
+              <ButtonRow>
                 <ButtonPrimary id="stableswap-add-liquidity-button" width="45%" onClick={handleAddLiquidity}>
                   Add
                 </ButtonPrimary>

--- a/src/components/PositionCard/StablePositionCard/index.tsx
+++ b/src/components/PositionCard/StablePositionCard/index.tsx
@@ -149,21 +149,6 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
       label: 'Virtual Price',
       value: stablePoolData.virtualPrice == null ? '-' : `$${stablePoolData.virtualPrice?.toFixed(6)}`,
       tooltipData: 'Average dollar value of pool token.'
-    },
-    {
-      label: 'Swap Fee',
-
-      value: stablePoolData.swapFee == null ? '-' : `${stablePoolData.swapFee?.toSignificant(2)}%`
-    },
-    {
-      label: 'Admin Fee',
-      value: stablePoolData.adminFee == null ? '-' : `${stablePoolData.adminFee?.toSignificant(2)}%`
-    },
-    {
-      label: 'Amplification coefficient',
-      value: stablePoolData.aParameter?.toString() ?? '-',
-      tooltipData:
-        "Higher values widen the range of low-slippages swaps, while lower values help keep the pool's composition balanced."
     }
   ]
 
@@ -193,6 +178,10 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
       </FixedHeightRow>
     )
   }
+
+  const poolTokensString = poolTokens
+    .map((token, index, arr) => `${token.symbol}${index + 1 < arr.length ? '/' : ''}`)
+    .join('')
 
   return (
     <StyledPositionCard border={border} bgColor={backgroundColor1} id={`stableswap-position-card-${name}`}>
@@ -229,18 +218,16 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
         {userData?.lpTokenBalance.greaterThan(BIG_INT_ZERO) ? (
           <AutoColumn gap="8px">
             <FixedHeightRow marginTop="4px">
-              <StyledText fontWeight={500}>Deposited Amount</StyledText>
-              <StyledText fontWeight={500}>{`$${userData?.usdBalance.toString()}`}</StyledText>
-            </FixedHeightRow>
-            <FixedHeightRow>
-              <StyledText fontWeight={500}>{stablePoolData.lpToken?.name} LP Token Balance</StyledText>
-              <StyledText fontWeight={500}>{`$${userData?.lpTokenBalance.toFixed(3)}`}</StyledText>
+              <StyledText fontWeight={500}>User {poolTokensString} LP Balance:</StyledText>
+              <StyledText fontWeight={500}>{`$${userData?.usdBalance.toString()} (${userData?.lpTokenBalance.toFixed(
+                3
+              )} LP tokens) `}</StyledText>
             </FixedHeightRow>
           </AutoColumn>
         ) : null}
 
         {showMore && (
-          <div style={{ marginTop: '20px' }}>
+          <div style={{ marginTop: '14px' }}>
             <AutoColumn gap="8px">
               <TYPE.subHeader fontSize={16} fontWeight={600}>
                 Currency Reserves

--- a/src/components/PositionCard/StablePositionCard/index.tsx
+++ b/src/components/PositionCard/StablePositionCard/index.tsx
@@ -1,8 +1,8 @@
 import { ChainId, Pair } from '@trisolaris/sdk'
 import { darken } from 'polished'
-import React, { useState } from 'react'
+import React, { useState, useContext } from 'react'
 import { Text } from 'rebass'
-import styled from 'styled-components'
+import styled, { ThemeContext } from 'styled-components'
 import { unwrappedToken } from '../../../utils/wrappedCurrency'
 import { ButtonPrimary } from '../../Button'
 import { ChevronDown, ChevronUp } from 'react-feather'
@@ -28,6 +28,7 @@ import ContractAddress from '../../ContractAddress'
 import { TYPE } from '../../../theme'
 import { HelpCircle } from 'lucide-react'
 import { MouseoverTooltip } from '../../Tooltip'
+import { useWindowSize } from '../../../hooks/useWindowSize'
 
 export const FixedHeightRow = styled(RowBetween)`
   height: 24px;
@@ -76,6 +77,23 @@ const StyledFixedHeightRow = styled(FixedHeightRow)`
   cursor: pointer;
 `
 
+const StyledMouseoverTooltip = styled(MouseoverTooltip)`
+  font-size: 0.9rem;
+  text-align: center;
+  min-width: 360px;
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+  min-width: 190px;
+  font-size: 0.75rem;
+  `};
+`
+
+const StyledColon = styled.span`
+  margin-left: 30px;
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+  margin-left: 22px;
+  `};
+`
+
 interface PositionCardProps {
   pair: Pair
   showUnwrapped?: boolean
@@ -94,6 +112,9 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
     location: { pathname },
     push
   } = useHistory()
+
+  const { width } = useWindowSize()
+  const theme = useContext(ThemeContext)
 
   const { name, poolTokens, address: poolAddress } = STABLESWAP_POOLS[ChainId.AURORA][poolName]
 
@@ -148,6 +169,29 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
     setShowMore(!showMore)
   }
 
+  const renderRow = ({ label, tooltipData, value }: { label: string; tooltipData?: string; value: string }) => {
+    return (
+      <FixedHeightRow key={label}>
+        <StyledText fontWeight={500} style={{ zIndex: 1, display: 'flex' }}>
+          {`${label}${tooltipData ? '' : ':'}`}
+          {tooltipData && (
+            <>
+              <StyledMouseoverTooltip text={tooltipData} placement="top">
+                <HelpCircle
+                  size={width && width < theme.viewPorts.upToExtraSmall ? 14 : 20}
+                  style={{ cursor: 'pointer', position: 'absolute', margin: '0 2px 0 5px' }}
+                />
+              </StyledMouseoverTooltip>
+              <StyledColon>:</StyledColon>
+            </>
+          )}
+        </StyledText>
+
+        <StyledText fontWeight={500}>{value}</StyledText>
+      </FixedHeightRow>
+    )
+  }
+
   return (
     <StyledPositionCard border={border} bgColor={backgroundColor1} id={`stableswap-position-card-${name}`}>
       <TokenPairBackgroundColor bgColor1={backgroundColor1} bgColor2={backgroundColor2} />
@@ -194,7 +238,7 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
         ) : null}
 
         {showMore && (
-          <div style={{ marginTop: '10px' }}>
+          <div style={{ marginTop: '20px' }}>
             <AutoColumn gap="8px">
               <TYPE.subHeader fontSize={16} fontWeight={500}>
                 Currency Reserves
@@ -214,6 +258,9 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
               <TYPE.subHeader fontSize={16} fontWeight={500} marginTop="8px">
                 Pool Info
               </TYPE.subHeader>
+              {formattedPoolData
+                .slice(0, 1)
+                .map(({ label, value, tooltipData }) => renderRow({ label, value, tooltipData }))}
               <FixedHeightRow>
                 <StyledText>Swap Fee:</StyledText>
                 <StyledText>
@@ -259,6 +306,9 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
                   <StyledText fontWeight={500}>{value}</StyledText>
                 </FixedHeightRow>
               ))}
+              {formattedPoolData
+                .slice(1)
+                .map(({ label, value, tooltipData }) => renderRow({ label, value, tooltipData }))}
             </AutoColumn>
             <AutoColumn gap="8px" style={{ marginTop: '10px' }}>
               <ButtonRow>

--- a/src/pages/StableSwapPool/index.tsx
+++ b/src/pages/StableSwapPool/index.tsx
@@ -37,7 +37,7 @@ export default function Pool() {
           <TitleRow style={{ marginTop: '1rem' }} padding={'0'}>
             <HideSmall>
               <TYPE.mediumHeader style={{ marginTop: '0.5rem', justifySelf: 'flex-start' }}>
-                {t('pool.yourLiquidity')}
+                Stable Pools
               </TYPE.mediumHeader>
             </HideSmall>
           </TitleRow>

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -121,7 +121,9 @@ export function theme(darkMode: boolean): DefaultTheme {
       flex-flow: row nowrap;
     `,
 
-    pageWidth: '720px'
+    pageWidth: '720px',
+
+    viewPorts: MEDIA_WIDTHS
   }
 }
 

--- a/src/theme/styled.d.ts
+++ b/src/theme/styled.d.ts
@@ -80,5 +80,14 @@ declare module 'styled-components' {
     flexRowNoWrap: FlattenSimpleInterpolation
 
     pageWidth: string
+
+    viewPorts: {
+      upToXxxSmall: number
+      upToXxSmall: number
+      upToExtraSmall: number
+      upToSmall: number
+      upToMedium: number
+      upToLarge: number
+    }
   }
 }


### PR DESCRIPTION
- Adding questionMark icon helpers for stableswap pool cards.
- Removing fees data
- Changing deposit copies.

<img width="963" alt="Screen Shot 2022-03-30 at 13 34 32" src="https://user-images.githubusercontent.com/96993065/160886069-1fb248a3-396b-4a09-974b-aa5ee8bc54ab.png">

