### PR TITLE
Fix stake button displaying insuficcient balance when input is not modified

### DIFF
--- a/src/pages/StakeTri/index.tsx
+++ b/src/pages/StakeTri/index.tsx
@@ -107,12 +107,6 @@ export default function StakeTri() {
     _setInput(amount)
   }
 
-  const handleClickMax = useCallback(() => {
-    if (maxAmountInput) {
-      setInput(maxAmountInput.toExact())
-    }
-  }, [maxAmountInput, setInput])
-
   function renderApproveButton() {
     if (!isStaking) {
       return null
@@ -139,7 +133,7 @@ export default function StakeTri() {
   function renderStakeButton() {
     // If account balance is less than inputted amount
     const insufficientFunds = (balance?.equalTo(BIG_INT_ZERO) ?? false) || parsedAmount?.greaterThan(balance)
-    if (insufficientFunds) {
+    if (insufficientFunds && parsedAmount?.greaterThan(BIG_INT_ZERO)) {
       return (
         <ButtonError error={true} disabled={true}>
           Insufficient Balance


### PR DESCRIPTION
Fix stake button displaying insufficient balance before user changing input  :
<img width="786" alt="Screen Shot 2022-04-01 at 19 27 47" src="https://user-images.githubusercontent.com/96993065/161350141-6744fe70-959b-4708-8c33-571eb8c64188.png">

After:
<img width="825" alt="Screen Shot 2022-04-01 at 19 27 58" src="https://user-images.githubusercontent.com/96993065/161350136-abbb8ee1-6652-4366-b955-154e7eed55b2.png">

