### PR TITLE
Added XTRI and LUNAR to max hops custom list

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -227,4 +227,8 @@ export const TOKEN_WARNING_MODAL_ALLOWLIST = new Set(
   ].map(({ address }) => address.toLowerCase())
 )
 
-export const CUSTOM_TOKEN_MAX_HOPS = { [TRIPOLAR[ChainId.AURORA].address]: 4 }
+export const CUSTOM_TOKEN_MAX_HOPS = {
+  [TRIPOLAR[ChainId.AURORA].address]: 4,
+  [XTRI[ChainId.AURORA].address]: 4,
+  [LUNAR[ChainId.AURORA].address]: 4
+}


### PR DESCRIPTION
Added LUNAR and XTRI to 4 hops token list.

Makes sense to add XTRI as it's pool with more liquidity is with STNEAR, which probably always needs one routing hop more for swapping from/to wnear first.