### PR TITLE
Fix 4pool showing 5 inputs on add liquidity

### DIFF
--- a/src/state/stableswap-add-liquidity/hooks.ts
+++ b/src/state/stableswap-add-liquidity/hooks.ts
@@ -48,10 +48,10 @@ export function useDerivedStableSwapAddLiquidityInfo(
   } = useStableSwapAddLiquidityState()
 
   const { lpToken, poolTokens } = STABLESWAP_POOLS[stableSwapPoolName]
-  const [currency0, currency1, currency2, currency3] = poolTokens.map(token => unwrappedToken(token))
+  const [currency0, currency1, currency2, currency3, currency4] = poolTokens.map(token => unwrappedToken(token))
   const hasThirdCurrency = currency2 != null
   const hasFourthCurrency = hasThirdCurrency && currency3 != null
-  const hasFifthCurrency = hasFourthCurrency && currency3 != null
+  const hasFifthCurrency = hasFourthCurrency && currency4 != null
 
   // tokens
   const currencies: { [field in Field]?: Currency } = useMemo(


### PR DESCRIPTION
<img width="493" alt="Screen Shot 2022-04-26 at 18 11 48" src="https://user-images.githubusercontent.com/96993065/165393327-9af724ee-d4cd-43ed-aff5-8c4e3dbfebb2.png">

Fixed, also tested adding and removing liq just in case:

https://aurorascan.dev/tx/0x7f12c7716b902208971c940cccae5802a7650e4be90789f7bd2444d3a1f657ae
https://aurorascan.dev/tx/0x6cd02e790ab8d208212486c1593196817b8f240e1c077fb7610b167d85f2338f