### PR TITLE
fix token list schema for symbols in token names

### DIFF
--- a/src/constants/tokens/tokenListValidationSchema.json
+++ b/src/constants/tokens/tokenListValidationSchema.json
@@ -167,7 +167,7 @@
             "description": "The name of the token",
             "minLength": 1,
             "maxLength": 40,
-            "pattern": "^[ \\w.'+\\-%\\/À-ÖØ-öø-ÿ:]+$",
+            "pattern": "^[ \\w.'+\\-%/À-ÖØ-öø-ÿ:&\\[\\]\\(\\)]+$",
             "examples": [
               "USD Coin"
             ]


### PR DESCRIPTION
Added support in token list schema validator for parenthesis in token *name*, in order to support "WUST (Wormhole)"
 
note: pattern was copied and verified from uniswap and aurora's validator schemas