### PR TITLE
fix(src/state|pages/swap, src/components/swap/advancedswapdetails.*): if no trade, show stableswap

### DIFF
--- a/src/components/swap/AdvancedSwapDetails.tsx
+++ b/src/components/swap/AdvancedSwapDetails.tsx
@@ -12,7 +12,7 @@ import { SectionBreak } from './styleds'
 import SwapRoute from './SwapRoute'
 import { useTranslation } from 'react-i18next'
 
-import { useDerivedStableSwapInfo } from '../../state/stableswap/hooks'
+import { StableSwapTrade, useDerivedStableSwapInfo } from '../../state/stableswap/hooks'
 
 function TradeSummary({
   trade,
@@ -105,8 +105,78 @@ function TradeSummary({
   )
 }
 
+function StableTradeSummary({
+  stableswapPriceImpactWithoutFee,
+  allowedSlippage,
+  isRoutedViaStableSwap,
+  isStableSwapPriceImpactSevere
+}: {
+  stableswapPriceImpactWithoutFee: Percent
+  allowedSlippage: number
+  isRoutedViaStableSwap: boolean
+  isStableSwapPriceImpactSevere: boolean
+}) {
+  const theme = useContext(ThemeContext)
+  const { stableswapTrade } = useDerivedStableSwapInfo()
+  const { t } = useTranslation()
+
+  const receivedAmountEstimate =
+    (isRoutedViaStableSwap &&
+      `${stableswapTrade?.outputAmountLessSlippage.toSignificant(4)} ${
+        stableswapTrade?.outputAmountLessSlippage.currency.symbol
+      }`) ??
+    '-'
+
+  return (
+    <>
+      <AutoColumn gap="4px" style={{ padding: '0 20px' }}>
+        <RowBetween>
+          <RowFixed>
+            <TYPE.black fontSize={14} fontWeight={400} color={theme.text2}>
+              {t('swap.minimumReceived')}
+            </TYPE.black>
+          </RowFixed>
+          <RowFixed>
+            <TYPE.black color={theme.text1} fontSize={14}>
+              {receivedAmountEstimate}
+            </TYPE.black>
+          </RowFixed>
+        </RowBetween>
+        <RowBetween>
+          <RowFixed>
+            <TYPE.black fontSize={14} fontWeight={400} color={theme.text2}>
+              {t('swap.priceImpact')}
+            </TYPE.black>
+          </RowFixed>
+          <FormattedPriceImpact
+            isStableSwapPriceImpactSevere={isStableSwapPriceImpactSevere}
+            priceImpact={stableswapPriceImpactWithoutFee}
+            isRoutedViaStableSwap={isRoutedViaStableSwap}
+          />
+        </RowBetween>
+
+        <RowBetween>
+          <RowFixed>
+            <TYPE.black fontSize={14} fontWeight={400} color={theme.text2}>
+              {t('swap.routedViaAmmType')}
+            </TYPE.black>
+          </RowFixed>
+          <TYPE.black
+            id={'swap-routed-via'}
+            fontSize={14}
+            color={isRoutedViaStableSwap ? theme.metallicGold : theme.yellow2}
+          >
+            {isRoutedViaStableSwap ? `Stable AMM` : 'Standard AMM'}
+          </TYPE.black>
+        </RowBetween>
+      </AutoColumn>
+    </>
+  )
+}
+
 export interface AdvancedSwapDetailsProps {
   trade?: Trade
+  stableswapTrade?: StableSwapTrade
   stableswapPriceImpactWithoutFee: Percent
   isRoutedViaStableSwap: boolean
   isStableSwapPriceImpactSevere: boolean
@@ -127,7 +197,7 @@ export function AdvancedSwapDetails({
 
   return (
     <AutoColumn gap="md">
-      {trade && (
+      {trade ? (
         <>
           <TradeSummary
             isRoutedViaStableSwap={isRoutedViaStableSwap}
@@ -152,6 +222,13 @@ export function AdvancedSwapDetails({
             </>
           )}
         </>
+      ) : (
+        <StableTradeSummary
+          isRoutedViaStableSwap={isRoutedViaStableSwap}
+          stableswapPriceImpactWithoutFee={stableswapPriceImpactWithoutFee}
+          allowedSlippage={allowedSlippage}
+          isStableSwapPriceImpactSevere={isStableSwapPriceImpactSevere}
+        />
       )}
     </AutoColumn>
   )

--- a/src/components/swap/AdvancedSwapDetailsDropdown.tsx
+++ b/src/components/swap/AdvancedSwapDetailsDropdown.tsx
@@ -19,11 +19,11 @@ export const AdvancedDetailsFooter = styled.div<{ show: boolean }>`
   transition: transform 300ms ease-in-out;
 `
 
-export default function AdvancedSwapDetailsDropdown({ trade, ...rest }: AdvancedSwapDetailsProps) {
+export default function AdvancedSwapDetailsDropdown({ trade, stableswapTrade, ...rest }: AdvancedSwapDetailsProps) {
   const lastTrade = useLastTruthy(trade)
 
   return (
-    <AdvancedDetailsFooter show={Boolean(trade)}>
+    <AdvancedDetailsFooter show={Boolean(trade) || Boolean(stableswapTrade)}>
       <AdvancedSwapDetails {...rest} trade={trade ?? lastTrade ?? undefined} />
     </AdvancedDetailsFooter>
   )

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -143,6 +143,7 @@ export default function Swap() {
     useMemo(() => {
       if (isStableSwap) {
         const swapOutputRaw = parsedAmounts?.OUTPUT?.raw
+        if (!swapOutputRaw && stableswapTrade) return true
         if (swapOutputRaw) {
           return JSBI.greaterThan(stableswapTrade?.outputAmount?.raw ?? JSBI.BigInt(0), swapOutputRaw)
         }
@@ -208,7 +209,7 @@ export default function Swap() {
   const userHasSpecifiedInputOutput = Boolean(
     currencies[Field.INPUT] && currencies[Field.OUTPUT] && parsedAmounts[independentField]?.greaterThan(BIG_INT_ZERO)
   )
-  const noRoute = !route
+  const noRoute = !route && !stableswapTrade?.stableSwapData?.route
 
   // check whether the user has approved the router on the input token
   const [defaultswapApproval, defaultswapApproveCallback] = useApproveCallbackFromTrade(trade, allowedSlippage)
@@ -614,6 +615,7 @@ export default function Swap() {
           </AppBody>
           <AdvancedSwapDetailsDropdown
             trade={trade}
+            stableswapTrade={stableswapTrade}
             isRoutedViaStableSwap={isRoutedViaStableSwap}
             stableswapPriceImpactWithoutFee={stableswapPriceImpactWithoutFee}
             isStableSwapPriceImpactSevere={isStableSwapPriceImpactSevere}

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -177,8 +177,16 @@ export function useDerivedSwapInfo(
     () =>
       find(STABLESWAP_POOLS, pool => {
         return (
-          Boolean(pool.poolTokens?.find(stableToken => stableToken?.symbol === currencies[Field.INPUT]?.symbol)) &&
-          Boolean(pool.poolTokens?.find(stableToken => stableToken?.symbol === currencies[Field.OUTPUT]?.symbol))
+          Boolean(
+            pool.poolTokens?.find(
+              stableToken => stableToken?.name?.toLowerCase() === currencies[Field.INPUT]?.name?.toLowerCase()
+            )
+          ) &&
+          Boolean(
+            pool.poolTokens?.find(
+              stableToken => stableToken?.name?.toLowerCase() === currencies[Field.OUTPUT]?.name?.toLowerCase()
+            )
+          )
         )
       })
         ? true


### PR DESCRIPTION
noRoute var logic for insufficient liquidity boolean, 
isStableSwap boolean conditional now based on name, 
show AdvancedSwapDetailsDropdown for stableswapTrade details