### PR TITLE
Fix confirmation modal footer

### DIFF
--- a/src/components/swap/ConfirmSwapModal.tsx
+++ b/src/components/swap/ConfirmSwapModal.tsx
@@ -80,7 +80,7 @@ export default function ConfirmSwapModal({
   }, [allowedSlippage, onAcceptChanges, recipient, showAcceptChanges, trade])
 
   const modalBottom = useCallback(() => {
-    return trade ? (
+    return trade || stableswapTrade ? (
       <SwapModalFooter
         onConfirm={onConfirm}
         trade={trade}

--- a/src/components/swap/ConfirmSwapModal.tsx
+++ b/src/components/swap/ConfirmSwapModal.tsx
@@ -77,7 +77,7 @@ export default function ConfirmSwapModal({
         stableSwapTrade={stableswapTrade}
       />
     ) : null
-  }, [allowedSlippage, onAcceptChanges, recipient, showAcceptChanges, trade])
+  }, [allowedSlippage, onAcceptChanges, recipient, showAcceptChanges, trade, isRoutedViaStableSwap, stableswapTrade])
 
   const modalBottom = useCallback(() => {
     return trade || stableswapTrade ? (
@@ -93,7 +93,17 @@ export default function ConfirmSwapModal({
         stableSwapTrade={stableswapTrade}
       />
     ) : null
-  }, [allowedSlippage, onConfirm, showAcceptChanges, swapErrorMessage, trade])
+  }, [
+    trade,
+    stableswapTrade,
+    onConfirm,
+    showAcceptChanges,
+    swapErrorMessage,
+    allowedSlippage,
+    isRoutedViaStableSwap,
+    stableswapPriceImpactWithoutFee,
+    isStableSwapPriceImpactSevere
+  ])
 
   const currentTrade = isRoutedViaStableSwap ? stableswapTrade : trade
   // text to show while loading

--- a/src/components/swap/SwapModalFooter.tsx
+++ b/src/components/swap/SwapModalFooter.tsx
@@ -57,7 +57,7 @@ export default function SwapModalFooter({
       <AutoColumn gap="0px">
         <RowBetween align="center">
           <Text fontWeight={400} fontSize={14} color={theme.text2}>
-            {t('swap.price')}
+            {t('swap.price')} {isRoutedViaStableSwap && ` (Slippage Tolerance)`}
           </Text>
           <Text
             fontWeight={500}
@@ -71,7 +71,7 @@ export default function SwapModalFooter({
               paddingLeft: '10px'
             }}
           >
-            {formatExecutionPrice(isRoutedViaStableSwap ? stableSwapTrade : trade, showInverted)}
+            {formatExecutionPrice(isRoutedViaStableSwap ? stableSwapTrade : trade, showInverted, isRoutedViaStableSwap)}
             <StyledBalanceMaxMini onClick={() => setShowInverted(!showInverted)}>
               <Repeat size={14} />
             </StyledBalanceMaxMini>

--- a/src/components/swap/SwapModalFooter.tsx
+++ b/src/components/swap/SwapModalFooter.tsx
@@ -31,7 +31,7 @@ export default function SwapModalFooter({
   isStableSwapPriceImpactSevere,
   stableSwapTrade
 }: {
-  trade: Trade
+  trade?: Trade
   allowedSlippage: number
   onConfirm: () => void
   swapErrorMessage: string | undefined
@@ -48,7 +48,8 @@ export default function SwapModalFooter({
     trade
   ])
   const { priceImpactWithoutFee, realizedLPFee } = useMemo(() => computeTradePriceBreakdown(trade), [trade])
-  const severity = warningSeverity(priceImpactWithoutFee)
+
+  const severity = warningSeverity(isRoutedViaStableSwap ? stableswapPriceImpactWithoutFee : priceImpactWithoutFee)
   const { t } = useTranslation()
 
   return (
@@ -80,7 +81,7 @@ export default function SwapModalFooter({
         <RowBetween>
           <RowFixed>
             <TYPE.black fontSize={14} fontWeight={400} color={theme.text2}>
-              {trade.tradeType === TradeType.EXACT_INPUT || isRoutedViaStableSwap
+              {trade?.tradeType === TradeType.EXACT_INPUT || isRoutedViaStableSwap
                 ? t('swap.minimumReceived')
                 : t('swap.maximumSold')}
             </TYPE.black>
@@ -90,16 +91,16 @@ export default function SwapModalFooter({
             <TYPE.black fontSize={14}>
               {isRoutedViaStableSwap
                 ? stableSwapTrade?.outputAmountLessSlippage.toSignificant(4)
-                : trade.tradeType === TradeType.EXACT_INPUT
+                : trade?.tradeType === TradeType.EXACT_INPUT
                 ? slippageAdjustedAmounts[Field.OUTPUT]?.toSignificant(4) ?? '-'
                 : slippageAdjustedAmounts[Field.INPUT]?.toSignificant(4) ?? '-'}
             </TYPE.black>
             <TYPE.black fontSize={14} marginLeft={'4px'}>
               {isRoutedViaStableSwap
                 ? stableSwapTrade?.outputAmount.currency.symbol
-                : trade.tradeType === TradeType.EXACT_INPUT
-                ? trade.outputAmount.currency.symbol
-                : trade.inputAmount.currency.symbol}
+                : trade?.tradeType === TradeType.EXACT_INPUT
+                ? trade?.outputAmount.currency.symbol
+                : trade?.inputAmount.currency.symbol}
             </TYPE.black>
           </RowFixed>
         </RowBetween>
@@ -125,7 +126,7 @@ export default function SwapModalFooter({
               <QuestionHelper text={t('swap.liquidityProviderHelper')} />
             </RowFixed>
             <TYPE.black fontSize={14}>
-              {realizedLPFee ? realizedLPFee?.toSignificant(6) + ' ' + trade.inputAmount.currency.symbol : '-'}
+              {realizedLPFee ? realizedLPFee?.toSignificant(6) + ' ' + trade?.inputAmount.currency.symbol : '-'}
             </TYPE.black>
           </RowBetween>
         )}

--- a/src/utils/prices.ts
+++ b/src/utils/prices.ts
@@ -1,5 +1,5 @@
 import { BIG_INT_ZERO, BLOCKED_PRICE_IMPACT_NON_EXPERT } from '../constants'
-import { CurrencyAmount, Fraction, JSBI, Percent, TokenAmount, Trade } from '@trisolaris/sdk'
+import { CurrencyAmount, Fraction, JSBI, Percent, Price, TokenAmount, Trade } from '@trisolaris/sdk'
 import { ALLOWED_PRICE_IMPACT_HIGH, ALLOWED_PRICE_IMPACT_LOW, ALLOWED_PRICE_IMPACT_MEDIUM } from '../constants'
 import { Field } from '../state/swap/actions'
 import { basisPointsToPercent } from './index'
@@ -71,15 +71,18 @@ export function warningSeverity(priceImpact: Percent | undefined): 0 | 1 | 2 | 3
   return 0
 }
 
-export function formatExecutionPrice(trade?: Trade | StableSwapTrade, inverted?: boolean): string {
+export function formatExecutionPrice(
+  trade?: Trade | StableSwapTrade,
+  inverted?: boolean,
+  isRoutedViaStableSwap?: boolean
+): string {
   if (!trade) {
     return ''
   }
-  return inverted
-    ? `${trade.executionPrice.invert().toSignificant(6)} ${trade.inputAmount.currency.symbol} / ${
-        trade.outputAmount.currency.symbol
-      }`
-    : `${trade.executionPrice.toSignificant(6)} ${trade.outputAmount.currency.symbol} / ${
-        trade.inputAmount.currency.symbol
-      }`
+
+  const rotatedTrade = inverted ? trade.executionPrice.invert() : trade.executionPrice
+
+  return `${isRoutedViaStableSwap ? rotatedTrade?.raw?.toSignificant(6) : rotatedTrade.toSignificant(6)} ${
+    inverted ? trade.outputAmount.currency.symbol : trade.inputAmount.currency.symbol
+  } / ${inverted ? trade.inputAmount.currency.symbol : trade.outputAmount.currency.symbol}`
 }


### PR DESCRIPTION
Fixing modal footer details not showing when no standard trade available. Previously not using stableswap data.

NOTE:  Price estimation needs to be fixed when stableswapping with tokens of different decimals.

<img width="522" alt="Screen Shot 2022-04-27 at 17 41 48" src="https://user-images.githubusercontent.com/96993065/165627381-aa0565dc-b8cf-4fb4-a97d-a55b1afaf736.png">

<img width="586" alt="Screen Shot 2022-04-27 at 17 41 55" src="https://user-images.githubusercontent.com/96993065/165627396-1fe8b8b5-60b0-472a-b80c-9a72e4070e12.png">
