### PR TITLE
Replaces underscores with slash for add/remove liq and LP token names

### DIFF
--- a/src/pages/StableSwapPoolAddLiquidity/StableSwapPoolAddLiquidityImpl.tsx
+++ b/src/pages/StableSwapPoolAddLiquidity/StableSwapPoolAddLiquidityImpl.tsx
@@ -21,7 +21,7 @@ import { useTranslation } from 'react-i18next'
 import BalanceButtonValueEnum from '../../components/BalanceButton/BalanceButtonValueEnum'
 import useCurrencyInputPanel from '../../components/CurrencyInputPanel/useCurrencyInputPanel'
 import { StableSwapPoolName } from '../../state/stableswap/constants'
-import { divideCurrencyAmountByNumber } from '../../utils'
+import { divideCurrencyAmountByNumber, replaceUnderscoresWithSlashes } from '../../utils'
 import StableSwapPoolAddLiquidityApprovalsRow from './StableSwapPoolAddLiquidityApprovalsRow'
 import { TYPE } from '../../theme'
 import Settings from '../../components/Settings'
@@ -37,6 +37,7 @@ import { RowBetween } from '../../components/Row'
 import { JSBI } from '@trisolaris/sdk'
 import { BIG_INT_ZERO } from '../../constants'
 import { useExpertModeManager } from '../../state/user/hooks'
+import useStablePoolsData from '../../hooks/useStablePoolsData'
 
 type Props = {
   stableSwapPoolName: StableSwapPoolName
@@ -44,7 +45,7 @@ type Props = {
 
 export default function StableSwapPoolAddLiquidityImpl({ stableSwapPoolName }: Props) {
   const { account, chainId, library } = useActiveWeb3React()
-
+  const [poolData, _userShareData] = useStablePoolsData(stableSwapPoolName)
   const { t } = useTranslation()
 
   const toggleWalletModal = useWalletModalToggle() // toggle wallet when disconnected
@@ -129,7 +130,7 @@ export default function StableSwapPoolAddLiquidityImpl({ stableSwapPoolName }: P
     onField4Input('')
 
     setTxHash('')
-  }, [onField0Input, onField1Input, onField2Input, setTxHash])
+  }, [onField0Input, onField1Input, onField2Input, onField3Input, onField4Input, setTxHash])
 
   const pendingText = `Supplying ${Object.values(parsedAmounts)
     .map(amount => (amount ? `${amount?.toSignificant(6)} ${amount?.currency.symbol}  ` : ''))
@@ -191,7 +192,7 @@ export default function StableSwapPoolAddLiquidityImpl({ stableSwapPoolName }: P
             />
             <HeadingContainer>
               <AutoRow>
-                <TYPE.mediumHeader>Add Liquidity to {stableSwapPoolName}</TYPE.mediumHeader>
+                <TYPE.mediumHeader>Add Liquidity to {replaceUnderscoresWithSlashes(poolData.name)}</TYPE.mediumHeader>
                 <CaptionWithIcon>Stable pools on Trisolaris support uneven deposits</CaptionWithIcon>
               </AutoRow>
               <Settings />

--- a/src/pages/StableSwapPoolRemoveLiquidity/StableSwapPoolRemoveLiquidityImpl.tsx
+++ b/src/pages/StableSwapPoolRemoveLiquidity/StableSwapPoolRemoveLiquidityImpl.tsx
@@ -35,6 +35,7 @@ import MultipleCurrencyLogo from '../../components/MultipleCurrencyLogo'
 import { ButtonPrimary } from '../../components/Button'
 import { useExpertModeManager } from '../../state/user/hooks'
 import Settings from '../../components/Settings'
+import { replaceUnderscoresWithSlashes } from '../../utils'
 
 const INPUT_CHAR_LIMIT = 18
 
@@ -226,7 +227,9 @@ export default function StableSwapPoolAddLiquidity({ stableSwapPoolName }: Props
         <DarkGreyCard>
           <AutoColumn gap="20px">
             <AutoRow justify="space-between">
-              <TYPE.mediumHeader>Remove Liquidity from {poolData.name}</TYPE.mediumHeader>
+              <TYPE.mediumHeader>
+                Remove Liquidity from {replaceUnderscoresWithSlashes(poolData.name)}
+              </TYPE.mediumHeader>
               <Settings />
             </AutoRow>
             <StableSwapRemoveLiquidityInputPanel

--- a/src/state/stableswap/constants.ts
+++ b/src/state/stableswap/constants.ts
@@ -1,6 +1,6 @@
 import { ChainId, Token, WETH } from '@trisolaris/sdk'
 import _ from 'lodash'
-import { FRAX, USDC, USDT, WBTC, WUST, USN} from '../../constants/tokens'
+import { FRAX, USDC, USDT, WBTC, WUST, USN } from '../../constants/tokens'
 
 export function isLegacySwapABIPool(poolName: string): boolean {
   return new Set(['dummy value']).has(poolName)
@@ -106,7 +106,7 @@ export const STABLESWAP_POOLS: StableSwapPools = {
       '0xcdb578ba21c65dbab2f2aa1ce912d689affda911',
       18,
       'USD TLP',
-      'UST_FRAX_USDC_USDT'
+      'UST/FRAX/USDC/USDT'
     ),
     poolTokens: [USDC[ChainId.AURORA], USDT[ChainId.AURORA], WUST[ChainId.AURORA], FRAX[ChainId.AURORA]],
     address: '0x21e756AF5a42838B4f17C3A70a395D3048da81D8',
@@ -122,9 +122,15 @@ export const STABLESWAP_POOLS: StableSwapPools = {
       '0x467171053355Da79409bf2F931D21ab1f24Fe0A6',
       18,
       'USD TLP',
-      'USDC_USDT_WUST_FRAX_USN'
+      'USDC/USDT/WUST/FRAX/USN'
     ),
-    poolTokens: [USDC[ChainId.AURORA], USDT[ChainId.AURORA], WUST[ChainId.AURORA], FRAX[ChainId.AURORA], USN[ChainId.AURORA]],
+    poolTokens: [
+      USDC[ChainId.AURORA],
+      USDT[ChainId.AURORA],
+      WUST[ChainId.AURORA],
+      FRAX[ChainId.AURORA],
+      USN[ChainId.AURORA]
+    ],
     address: '0xdd407884589b23d2155923b8178bAA0c5725ad9c',
     type: StableSwapPoolTypes.USD,
     route: 'usd',

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -128,3 +128,7 @@ export function divideCurrencyAmountByNumber(numerator: CurrencyAmount | undefin
 
   return CurrencyAmount.fromRawAmount(currency, divisionResult)
 }
+
+export function replaceUnderscoresWithSlashes(value: string) {
+  return value.replace(/_/g, '/')
+}


### PR DESCRIPTION
- LP Tokens now render with `/` instead of `_`: 
<img width="765" alt="image" src="https://user-images.githubusercontent.com/94581898/166829405-56976720-0945-4041-afad-91c90b83ecff.png">
- Add liquidity:
<img width="446" alt="image" src="https://user-images.githubusercontent.com/94581898/166829457-d7e7bc60-659b-4036-8524-c0d10fe9534a.png">
- Remove liquidity: 
<img width="756" alt="image" src="https://user-images.githubusercontent.com/94581898/166829492-d77d1fa9-ba63-4b9e-a9b4-e8ed72777599.png">
