### PR TITLE
Updated swap button and swap handler to have control flow for stableswap price impact

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -261,15 +261,33 @@ export default function Swap() {
     JSBI.BigInt(-1),
     JSBI.divide(stableswapPriceImpact, JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(18)))
   )
-  const stableswapPriceImpactWithoutFee = hasPriceImpact
-    ? new Percent('0', '1')
-    : new Percent(
-        JSBI.multiply(JSBI.BigInt(-1), stableswapPriceImpact),
-        JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(18))
-      )
+  const stableswapPriceImpactWithoutFee = useMemo(
+    () =>
+      hasPriceImpact
+        ? new Percent('0', '1')
+        : new Percent(
+            JSBI.multiply(JSBI.BigInt(-1), stableswapPriceImpact),
+            JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(18))
+          ),
+    [hasPriceImpact, stableswapPriceImpact]
+  )
+
+  // warnings on slippage
+  const defaultswapPriceImpactSeverity = warningSeverity(defaultswapPriceImpactWithoutFee)
+  const isStableSwapPriceImpactSevere = isStableSwapHighPriceImpact(stableswapPriceImpact)
 
   const handleSwap = useCallback(() => {
-    if (defaultswapPriceImpactWithoutFee && !confirmPriceImpactWithoutFee(defaultswapPriceImpactWithoutFee)) {
+    if (
+      isRoutedViaStableSwap &&
+      isStableSwapPriceImpactSevere &&
+      !confirmPriceImpactWithoutFee(stableswapPriceImpactWithoutFee)
+    ) {
+      return
+    } else if (
+      !isRoutedViaStableSwap &&
+      defaultswapPriceImpactWithoutFee &&
+      !confirmPriceImpactWithoutFee(defaultswapPriceImpactWithoutFee)
+    ) {
       return
     }
 
@@ -301,23 +319,22 @@ export default function Swap() {
         })
       })
   }, [
+    isRoutedViaStableSwap,
+    isStableSwapPriceImpactSevere,
+    stableswapPriceImpactWithoutFee,
+    defaultswapPriceImpactWithoutFee,
     tradeToConfirm,
-    account,
+    showConfirm,
+    stableswapCallback,
+    swapCallback,
     recipient,
     recipientAddress,
-    showConfirm,
-    swapCallback,
-    trade,
-    isRoutedViaStableSwap,
-    stableswapCallback,
-    defaultswapPriceImpactWithoutFee
+    account,
+    trade?.inputAmount?.currency?.symbol,
+    trade?.outputAmount?.currency?.symbol
   ])
 
   const isAEBToken = useIsSelectedAEBToken()
-
-  // warnings on slippage
-  const defaultswapPriceImpactSeverity = warningSeverity(defaultswapPriceImpactWithoutFee)
-  const isStableSwapPriceImpactSevere = isStableSwapHighPriceImpact(stableswapPriceImpact)
 
   const onlyExpertTrade = isRoutedViaStableSwap ? isStableSwapPriceImpactSevere : defaultswapPriceImpactSeverity > 3
   const highImpactTrade = isRoutedViaStableSwap ? isStableSwapPriceImpactSevere : defaultswapPriceImpactSeverity > 2
@@ -568,7 +585,7 @@ export default function Swap() {
                       width="48%"
                       id="swap-button"
                       disabled={!isValid || approval !== ApprovalState.APPROVED || (!isExpertMode && onlyExpertTrade)}
-                      error={isValid && defaultswapPriceImpactSeverity > 2}
+                      error={isValid && highImpactTrade}
                     >
                       <Text fontSize={16} fontWeight={500}>
                         {renderSwapText()}


### PR DESCRIPTION
- Fixes `Swap` button being erroneously red
- Fixes Price Impact modal erroneously showing 

Before:
![image](https://user-images.githubusercontent.com/94581898/166948374-be0fe069-b98c-4380-8b4c-580e14ae8fca.png)
![image](https://user-images.githubusercontent.com/94581898/166948388-e2d6b51e-2577-4ef6-abe9-aad7b2d730be.png)
![image](https://user-images.githubusercontent.com/94581898/166948395-b9a1889d-cf68-4784-9474-203b68c1d79b.png)

After:

https://user-images.githubusercontent.com/94581898/166948509-61daa1fb-c1ca-4a5b-95b4-22d61b967d4c.mov


