### PR TITLE
Fix 5pool name overflowing on mobile

### DIFF
--- a/src/components/PositionCard/StablePositionCard/index.tsx
+++ b/src/components/PositionCard/StablePositionCard/index.tsx
@@ -63,8 +63,12 @@ const StyledText = styled(Text)`
 `
 
 const StyledPoolName = styled(Text)`
+  word-break: break-word;
   ${({ theme }) => theme.mediaWidth.upToExtraSmall`
 font-size: 16px !important;
+`};
+${({ theme }) => theme.mediaWidth.upToXxSmall`
+font-size: 14px !important;
 `};
 `
 
@@ -90,6 +94,12 @@ const StyledContractAddress = styled(ContractAddress)`
   font-size: 16px;
   ${({ theme }) => theme.mediaWidth.upToExtraSmall`
 font-size: 12px !important;
+`};
+`
+
+const StyledViewDetails = styled(StyledText)`
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+display:none;
 `};
 `
 
@@ -188,7 +198,7 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
           </RowFixed>
 
           <RowFixed justify="flex-end" gap="8px">
-            <StyledText fontWeight={500}>{showMore ? 'Hide Details' : 'View Details'}</StyledText>
+            <StyledViewDetails fontWeight={500}>{showMore ? 'Hide Details' : 'View Details'}</StyledViewDetails>
             {showMore ? (
               <ChevronUp size="20" style={{ marginLeft: '10px' }} />
             ) : (

--- a/src/components/PositionCard/StablePositionCard/index.tsx
+++ b/src/components/PositionCard/StablePositionCard/index.tsx
@@ -67,7 +67,7 @@ const StyledPoolName = styled(Text)`
   ${({ theme }) => theme.mediaWidth.upToExtraSmall`
 font-size: 16px !important;
 `};
-${({ theme }) => theme.mediaWidth.upToXxSmall`
+  ${({ theme }) => theme.mediaWidth.upToXxSmall`
 font-size: 14px !important;
 `};
 `
@@ -188,7 +188,7 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
   return (
     <StyledPositionCard border={border} bgColor={backgroundColor1} id={`stableswap-position-card-${name}`}>
       <TokenPairBackgroundColor bgColor1={backgroundColor1} bgColor2={backgroundColor2} />
-      <AutoColumn gap="8px">
+      <AutoColumn gap="10px">
         <StyledFixedHeightRow onClick={handleCardClick} id={`stableswap-compact-clickable-position-card-${name}`}>
           <RowFixed>
             <MultipleCurrencyLogo currencies={currencies} size={20} />


### PR DESCRIPTION
- Remove view details text on mobile and make pool name smaller on very small devices

Before:
<img width="430" alt="Screen Shot 2022-05-05 at 15 47 29" src="https://user-images.githubusercontent.com/96993065/167003064-022dbc53-911d-4ba3-8023-41ad4aa3f70a.png">

After:

mobile:
<img width="407" alt="Screen Shot 2022-05-05 at 15 44 31" src="https://user-images.githubusercontent.com/96993065/167001376-6cc8aaa2-0689-4dd0-881f-cafd36ebbd18.png">


Desktop:
<img width="841" alt="Screen Shot 2022-05-05 at 15 36 25" src="https://user-images.githubusercontent.com/96993065/167001568-fefc8d2a-f84d-4022-8e6b-5b5bd85afe5b.png">
