### PR TITLE
Fix lunar/polar/atluna routing

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -58,7 +58,9 @@ const COMMON_BASES: ChainTokenList = {
     XTRI[ChainId.AURORA],
     WNEAR[ChainId.AURORA],
     STNEAR[ChainId.AURORA],
-    PLY[ChainId.AURORA]
+    PLY[ChainId.AURORA],
+    LUNAR[ChainId.AURORA],
+    POLAR[ChainId.AURORA]
   ]
 }
 
@@ -246,7 +248,8 @@ export const TOKEN_WARNING_MODAL_ALLOWLIST = new Set(
 export const CUSTOM_TOKEN_MAX_HOPS = {
   [TRIPOLAR[ChainId.AURORA].address]: 4,
   [XTRI[ChainId.AURORA].address]: 4,
-  [LUNAR[ChainId.AURORA].address]: 4
+  [LUNAR[ChainId.AURORA].address]: 4,
+  [ATLUNA[ChainId.AURORA].address]: 4
 }
 
 export const ENABLE_STABLE_FARMS = process.env.REACT_APP_ENABLE_STABLE_FARMS === 'true'


### PR DESCRIPTION
- Add lunar and polar as common routing bases. 
- Add atLuna to 4 hops list.

Before/After:

Lunar -> USDC

<img width="764" alt="Screen Shot 2022-05-10 at 13 21 59" src="https://user-images.githubusercontent.com/96993065/167676297-6a094106-d488-47f8-84e4-69003757a634.png">

atLuna => Polar
<img width="767" alt="Screen Shot 2022-05-10 at 13 29 47" src="https://user-images.githubusercontent.com/96993065/167677741-c980b551-64bc-4872-bca5-be0be47b468d.png">

atLuna => USDC

<img width="736" alt="Screen Shot 2022-05-10 at 13 39 22" src="https://user-images.githubusercontent.com/96993065/167679514-a00ff81e-4eb0-4215-a234-92fc63693c9f.png">

