### PR TITLE
Created n rewarder components for updated APR api

### DIFF
--- a/src/components/CurrencyLogo/index.tsx
+++ b/src/components/CurrencyLogo/index.tsx
@@ -29,11 +29,13 @@ const StyledLogo = styled(Logo)<{ size: string }>`
 `
 
 export default function CurrencyLogo({
+  alt,
   currency,
   size = '24px',
   style,
   ...rest
 }: {
+  alt?: string
   currency?: Currency
   size?: string
   style?: React.CSSProperties
@@ -77,5 +79,7 @@ export default function CurrencyLogo({
     }
   }
 
-  return <StyledLogo size={size} srcs={srcs} alt={`${currency?.symbol ?? 'token'} logo`} style={style} {...rest}/>
+  return (
+    <StyledLogo size={size} srcs={srcs} alt={alt ?? `${currency?.symbol ?? 'token'} logo`} style={style} {...rest} />
+  )
 }

--- a/src/components/earn/PoolCardTri.styles.tsx
+++ b/src/components/earn/PoolCardTri.styles.tsx
@@ -83,4 +83,5 @@ export const TokenPairBackgroundColor = styled.span<{ bgColor1: string | null; b
   top: 0;
   left: 0;
   user-select: none;
+  z-index: -1;
 `

--- a/src/components/earn/PoolCardTri.tsx
+++ b/src/components/earn/PoolCardTri.tsx
@@ -46,7 +46,7 @@ export type PoolCardTriProps = {
   isStaking: boolean
   version: number
   stableSwapPoolName?: StableSwapPoolName
-  nonTriAPRs?: NonTriAPR[]
+  nonTriAPRs: NonTriAPR[]
 }
 
 const DefaultPoolCardtri = ({

--- a/src/components/earn/PoolCardTri.tsx
+++ b/src/components/earn/PoolCardTri.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Token, ChainId } from '@trisolaris/sdk'
+import { Token } from '@trisolaris/sdk'
 import { useTranslation } from 'react-i18next'
 import { useHistory } from 'react-router-dom'
 import { Settings2 as ManageIcon } from 'lucide-react'
@@ -11,7 +11,7 @@ import { AutoRow, RowBetween } from '../Row'
 import ClaimRewardModal from '../../components/earn/ClaimRewardModalTri'
 import MultipleCurrencyLogo from '../MultipleCurrencyLogo'
 
-import { ChefVersions } from '../../state/stake/stake-constants'
+import { ChefVersions, NonTriAPR } from '../../state/stake/stake-constants'
 import { useSingleFarm } from '../../state/stake/user-farms'
 import { useColorForToken } from '../../hooks/useColor'
 import { currencyId } from '../../utils/currencyId'
@@ -29,8 +29,9 @@ import {
 import GetTokenLink from './FarmsPortfolio/GetTokenLink'
 import { StableSwapPoolName } from '../../state/stableswap/constants'
 import { useSingleStableFarm } from '../../state/stake/user-stable-farms'
+import PoolCardTriRewardText from './PoolCardTriRewardText'
 
-type PoolCardTriProps = {
+export type PoolCardTriProps = {
   apr: number
   apr2: number
   doubleRewards: boolean
@@ -45,25 +46,24 @@ type PoolCardTriProps = {
   isStaking: boolean
   version: number
   stableSwapPoolName?: StableSwapPoolName
+  nonTriAPRs?: NonTriAPR[]
 }
 
 const DefaultPoolCardtri = ({
   apr,
-  apr2,
   chefVersion,
   doubleRewards,
   inStaging,
-  noTriRewards,
   isLegacy,
   isPeriodFinished,
   tokens: _tokens,
   totalStakedInUSD,
-  doubleRewardToken,
   isStaking,
   version,
   enableClaimButton = false,
   enableModal = () => null,
-  stableSwapPoolName
+  stableSwapPoolName,
+  nonTriAPRs
 }: { enableClaimButton?: boolean; enableModal?: () => void } & PoolCardTriProps) => {
   const history = useHistory()
   const { t } = useTranslation()
@@ -142,15 +142,7 @@ const DefaultPoolCardtri = ({
         </AutoColumn>
         <AutoColumn>
           <TYPE.mutedSubHeader textAlign="end">APR</TYPE.mutedSubHeader>
-          <TYPE.white textAlign="end">
-            {isDualRewards && doubleRewards && !inStaging
-              ? `${apr}% TRI + ${`${apr2}%`} ${`${doubleRewardToken.symbol}`}`
-              : inStaging
-              ? `Coming Soon`
-              : noTriRewards
-              ? `${`${apr2}%`} ${`${doubleRewardToken.symbol}`}`
-              : `${apr}%`}
-          </TYPE.white>
+          <PoolCardTriRewardText apr={apr} inStaging={inStaging} nonTriAPRs={nonTriAPRs} />
         </AutoColumn>
       </RowBetween>
     </Wrapper>

--- a/src/components/earn/PoolCardTri.tsx
+++ b/src/components/earn/PoolCardTri.tsx
@@ -33,7 +33,6 @@ import PoolCardTriRewardText from './PoolCardTriRewardText'
 
 export type PoolCardTriProps = {
   apr: number
-  apr2: number
   doubleRewards: boolean
   chefVersion: ChefVersions
   inStaging: boolean

--- a/src/components/earn/PoolCardTriRewardText.tsx
+++ b/src/components/earn/PoolCardTriRewardText.tsx
@@ -57,7 +57,7 @@ export default function PoolCardTriRewardText({ apr, inStaging, nonTriAPRs }: Pr
           {tooltipData.map(({ token, apr }) => (
             <RowBetween key={token.address}>
               <AutoColumn justify="center" style={{ display: 'inline-flex' }}>
-                <CurrencyLogo currency={token} size={'16px'} />
+                <CurrencyLogo alt="" currency={token} size={'16px'} />
                 <TYPE.body marginLeft="0.5rem">{token.symbol}</TYPE.body>
               </AutoColumn>
               <AutoColumn style={{ marginLeft: '1rem' }}>
@@ -100,7 +100,7 @@ export default function PoolCardTriRewardText({ apr, inStaging, nonTriAPRs }: Pr
     <Popover content={tooltipContent} show={show}>
       <IconWrapper onMouseEnter={open} onMouseLeave={close}>
         {tooltipData.map(({ token }) => (
-          <CurrencyLogo currency={token} key={token.address} size={'16px'} style={{ marginRight: '4px' }} />
+          <CurrencyLogo alt="" currency={token} key={token.address} size={'16px'} style={{ marginRight: '4px' }} />
         ))}
         <TYPE.white marginRight="4px" textAlign="end">
           {totalAPR}%
@@ -114,7 +114,7 @@ export default function PoolCardTriRewardText({ apr, inStaging, nonTriAPRs }: Pr
 function PoolCardTriSingleCurrencyReward({ apr, token }: { apr: number; token: Token }) {
   return (
     <AutoRow alignItems="center">
-      <CurrencyLogo currency={token} size={'16px'} style={{ marginRight: '4px' }} />
+      <CurrencyLogo alt="" currency={token} size={'16px'} style={{ marginRight: '4px' }} />
       <TYPE.body>{apr}%</TYPE.body>
     </AutoRow>
   )

--- a/src/components/earn/PoolCardTriRewardText.tsx
+++ b/src/components/earn/PoolCardTriRewardText.tsx
@@ -50,45 +50,52 @@ export default function PoolCardTriRewardText({ apr, inStaging, nonTriAPRs }: Pr
     [apr, getTokenByAddress, nonTriAPRs]
   )
 
+  const tooltipContent = useMemo(
+    () => (
+      <ContentWrapper>
+        <AutoColumn style={{ padding: '0.25rem' }}>
+          {tooltipData.map(({ token, apr }) => (
+            <RowBetween key={token.address}>
+              <AutoColumn justify="center" style={{ display: 'inline-flex' }}>
+                <CurrencyLogo currency={token} size={'16px'} />
+                <TYPE.body marginLeft="0.5rem">{token.symbol}</TYPE.body>
+              </AutoColumn>
+              <AutoColumn style={{ marginLeft: '1rem' }}>
+                <TYPE.body>{apr}%</TYPE.body>
+              </AutoColumn>
+            </RowBetween>
+          ))}
+        </AutoColumn>
+      </ContentWrapper>
+    ),
+    [tooltipData]
+  )
+
   if (inStaging) {
     return <TYPE.white textAlign="end">Coming Soon</TYPE.white>
   }
 
-  const nonTriAPRTotal = nonTriAPRs?.reduce((acc, { apr }) => acc + apr, 0) ?? 0
+  const hasTriRewards = apr !== 0
+  const hasNonTriRewards = nonTriAPRs?.some(({ apr }) => apr > 0)
+  const hasOnlyTriRewards = hasTriRewards && !hasNonTriRewards
+  const hasOnlyNonTriRewards = !hasTriRewards && hasNonTriRewards
+  const hasMultipleNonTriRewards = hasNonTriRewards && Number(nonTriAPRs?.length) > 1
 
-  const hasOnlyTriReward = apr > 0 && nonTriAPRTotal === 0
-  if (hasOnlyTriReward || nonTriAPRs == null) {
+  // If only TRI rewards
+  if (hasOnlyTriRewards) {
     return <PoolCardTriSingleCurrencyReward apr={apr} token={TRI[ChainId.AURORA]} />
   }
 
-  const hasOnlyOneNonTriReward = !hasOnlyTriReward && nonTriAPRs?.length === 1
-  if (hasOnlyOneNonTriReward) {
+  // If only 1 non-TRI reward
+  if (hasOnlyNonTriRewards && !hasMultipleNonTriRewards) {
     const [rewardTokenData] = nonTriAPRs
     return (
       <PoolCardTriSingleCurrencyReward apr={rewardTokenData.apr} token={getTokenByAddress(rewardTokenData.address)} />
     )
   }
 
-  const tooltipContent = (
-    <ContentWrapper>
-      <AutoColumn style={{ padding: '0.25rem' }}>
-        {tooltipData.map(({ token, apr }) => (
-          <RowBetween key={token.address}>
-            <AutoColumn justify="center" style={{ display: 'inline-flex' }}>
-              <CurrencyLogo currency={token} size={'16px'} />
-              <TYPE.body marginLeft="0.5rem">{token.symbol}</TYPE.body>
-            </AutoColumn>
-            <AutoColumn style={{ marginLeft: '1rem' }}>
-              <TYPE.body>{Math.round(apr)}%</TYPE.body>
-            </AutoColumn>
-          </RowBetween>
-        ))}
-      </AutoColumn>
-    </ContentWrapper>
-  )
-
-  const totalAPR = nonTriAPRTotal + apr
-
+  // If multiple rewards, render aggregate APR, token logos, and tooltip
+  const totalAPR = (nonTriAPRs ?? []).reduce((acc, { apr: nonTriAPR }) => acc + nonTriAPR, apr)
   return (
     <Popover content={tooltipContent} show={show}>
       <IconWrapper onMouseEnter={open} onMouseLeave={close}>
@@ -96,7 +103,7 @@ export default function PoolCardTriRewardText({ apr, inStaging, nonTriAPRs }: Pr
           <CurrencyLogo currency={token} key={token.address} size={'16px'} style={{ marginRight: '4px' }} />
         ))}
         <TYPE.white marginRight="4px" textAlign="end">
-          {Math.round(totalAPR)}%
+          {totalAPR}%
         </TYPE.white>
         <Info size="16px" />
       </IconWrapper>

--- a/src/components/earn/PoolCardTriRewardText.tsx
+++ b/src/components/earn/PoolCardTriRewardText.tsx
@@ -80,6 +80,15 @@ export default function PoolCardTriRewardText({ apr, inStaging, nonTriAPRs }: Pr
   const hasOnlyTriRewards = hasTriRewards && !hasNonTriRewards
   const hasOnlyNonTriRewards = !hasTriRewards && hasNonTriRewards
   const hasMultipleNonTriRewards = hasNonTriRewards && Number(nonTriAPRs?.length) > 1
+  const hasNoRewards = !hasTriRewards && !hasNonTriRewards
+
+  if (hasNoRewards) {
+    return (
+      <AutoRow alignItems="center" justifyContent="space-evenly">
+        <TYPE.body>-</TYPE.body>
+      </AutoRow>
+    )
+  }
 
   // If only TRI rewards
   if (hasOnlyTriRewards) {

--- a/src/components/earn/PoolCardTriRewardText.tsx
+++ b/src/components/earn/PoolCardTriRewardText.tsx
@@ -1,0 +1,114 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import { ChainId, Token } from '@trisolaris/sdk'
+import { TYPE } from '../../theme'
+import { AutoColumn } from '../Column'
+import { AutoRow, RowBetween } from '../Row'
+import { TRI } from '../../constants/tokens'
+import Popover from '../Popover'
+import { PoolCardTriProps } from './PoolCardTri'
+import styled from 'styled-components'
+import { Info } from 'react-feather'
+import { useAllTokens } from '../../hooks/Tokens'
+import _ from 'lodash'
+import CurrencyLogo from '../CurrencyLogo'
+
+const IconWrapper = styled.div`
+  ${({ theme }) => theme.flexColumnNoWrap};
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.25rem;
+`
+
+const ContentWrapper = styled.div`
+  padding: 0.5rem 1rem;
+  width: fit-content;
+`
+
+type Props = Pick<PoolCardTriProps, 'apr' | 'inStaging' | 'nonTriAPRs'>
+
+export default function PoolCardTriRewardText({ apr, inStaging, nonTriAPRs }: Props) {
+  const [show, setShow] = useState(false)
+  const open = useCallback(() => setShow(true), [setShow])
+  const close = useCallback(() => setShow(false), [setShow])
+  const allTokens = useAllTokens()
+  const getTokenByAddress = useCallback(
+    address =>
+      _.find(allTokens, token => token.address.toLowerCase() === address.toLowerCase()) ??
+      new Token(ChainId.AURORA, address, 18),
+    [allTokens]
+  )
+  const tooltipData = useMemo(
+    () =>
+      [{ token: TRI[ChainId.AURORA], apr }].concat(
+        nonTriAPRs?.map(({ address, apr }) => ({
+          token: getTokenByAddress(address),
+          apr
+        })) ?? []
+      ),
+    [apr, getTokenByAddress, nonTriAPRs]
+  )
+
+  if (inStaging) {
+    return <TYPE.white textAlign="end">Coming Soon</TYPE.white>
+  }
+
+  const nonTriAPRTotal = nonTriAPRs?.reduce((acc, { apr }) => acc + apr, 0) ?? 0
+
+  const hasOnlyTriReward = apr > 0 && nonTriAPRTotal === 0
+  if (hasOnlyTriReward || nonTriAPRs == null) {
+    return <PoolCardTriSingleCurrencyReward apr={apr} token={TRI[ChainId.AURORA]} />
+  }
+
+  const hasOnlyOneNonTriReward = !hasOnlyTriReward && nonTriAPRs?.length === 1
+  if (hasOnlyOneNonTriReward) {
+    const [rewardTokenData] = nonTriAPRs
+    return (
+      <PoolCardTriSingleCurrencyReward apr={rewardTokenData.apr} token={getTokenByAddress(rewardTokenData.address)} />
+    )
+  }
+
+  const tooltipContent = (
+    <ContentWrapper>
+      <AutoColumn style={{ padding: '0.25rem' }}>
+        {tooltipData.map(({ token, apr }) => (
+          <RowBetween key={token.address}>
+            <AutoColumn justify="center" style={{ display: 'inline-flex' }}>
+              <CurrencyLogo currency={token} size={'16px'} />
+              <TYPE.body marginLeft="0.5rem">{token.symbol}</TYPE.body>
+            </AutoColumn>
+            <AutoColumn style={{ marginLeft: '1rem' }}>
+              <TYPE.body>{Math.round(apr)}%</TYPE.body>
+            </AutoColumn>
+          </RowBetween>
+        ))}
+      </AutoColumn>
+    </ContentWrapper>
+  )
+
+  const totalAPR = nonTriAPRTotal + apr
+
+  return (
+    <Popover content={tooltipContent} show={show}>
+      <IconWrapper onMouseEnter={open} onMouseLeave={close}>
+        {tooltipData.map(({ token }) => (
+          <CurrencyLogo currency={token} key={token.address} size={'16px'} style={{ marginRight: '4px' }} />
+        ))}
+        <TYPE.white marginRight="4px" textAlign="end">
+          {Math.round(totalAPR)}%
+        </TYPE.white>
+        <Info size="16px" />
+      </IconWrapper>
+    </Popover>
+  )
+}
+
+function PoolCardTriSingleCurrencyReward({ apr, token }: { apr: number; token: Token }) {
+  return (
+    <AutoRow alignItems="center">
+      <CurrencyLogo currency={token} size={'16px'} style={{ marginRight: '4px' }} />
+      <TYPE.body>{apr}%</TYPE.body>
+    </AutoRow>
+  )
+}

--- a/src/pages/EarnTri/EarnTri.tsx
+++ b/src/pages/EarnTri/EarnTri.tsx
@@ -55,7 +55,6 @@ export default function EarnTri({
                 <MemoizedPoolCardTRI
                   key={farm.ID}
                   apr={farm.apr}
-                  apr2={farm.apr2}
                   nonTriAPRs={farm.nonTriAPRs}
                   chefVersion={farm.chefVersion}
                   isPeriodFinished={farm.isPeriodFinished}
@@ -85,7 +84,6 @@ export default function EarnTri({
             <MemoizedPoolCardTRI
               key={farm.ID}
               apr={farm.apr}
-              apr2={farm.apr2}
               nonTriAPRs={farm.nonTriAPRs}
               chefVersion={farm.chefVersion}
               isPeriodFinished={farm.isPeriodFinished}
@@ -113,7 +111,6 @@ export default function EarnTri({
                 <MemoizedPoolCardTRI
                   key={farm.ID}
                   apr={farm.apr}
-                  apr2={farm.apr2}
                   nonTriAPRs={farm.nonTriAPRs}
                   chefVersion={farm.chefVersion}
                   isPeriodFinished={farm.isPeriodFinished}
@@ -141,7 +138,6 @@ export default function EarnTri({
               <MemoizedPoolCardTRI
                 key={farm.ID}
                 apr={farm.apr}
-                apr2={farm.apr2}
                 nonTriAPRs={farm.nonTriAPRs}
                 chefVersion={farm.chefVersion}
                 isLegacy={true}

--- a/src/pages/EarnTri/EarnTri.tsx
+++ b/src/pages/EarnTri/EarnTri.tsx
@@ -56,6 +56,7 @@ export default function EarnTri({
                   key={farm.ID}
                   apr={farm.apr}
                   apr2={farm.apr2}
+                  nonTriAPRs={farm.nonTriAPRs}
                   chefVersion={farm.chefVersion}
                   isPeriodFinished={farm.isPeriodFinished}
                   tokens={farm.tokens}
@@ -85,6 +86,7 @@ export default function EarnTri({
               key={farm.ID}
               apr={farm.apr}
               apr2={farm.apr2}
+              nonTriAPRs={farm.nonTriAPRs}
               chefVersion={farm.chefVersion}
               isPeriodFinished={farm.isPeriodFinished}
               tokens={farm.tokens}
@@ -112,6 +114,7 @@ export default function EarnTri({
                   key={farm.ID}
                   apr={farm.apr}
                   apr2={farm.apr2}
+                  nonTriAPRs={farm.nonTriAPRs}
                   chefVersion={farm.chefVersion}
                   isPeriodFinished={farm.isPeriodFinished}
                   tokens={farm.tokens}
@@ -139,6 +142,7 @@ export default function EarnTri({
                 key={farm.ID}
                 apr={farm.apr}
                 apr2={farm.apr2}
+                nonTriAPRs={farm.nonTriAPRs}
                 chefVersion={farm.chefVersion}
                 isLegacy={true}
                 isPeriodFinished={farm.isPeriodFinished}

--- a/src/pages/EarnTri/EarnTriStable.tsx
+++ b/src/pages/EarnTri/EarnTriStable.tsx
@@ -30,7 +30,6 @@ export default function EarnTri({ stablePoolsOrder }: { stablePoolsOrder: number
               <MemoizedPoolCardTRI
                 key={farm.ID}
                 apr={farm.apr}
-                apr2={farm.apr2}
                 nonTriAPRs={farm.nonTriAPRs}
                 chefVersion={farm.chefVersion}
                 isPeriodFinished={farm.isPeriodFinished}

--- a/src/pages/EarnTri/EarnTriStable.tsx
+++ b/src/pages/EarnTri/EarnTriStable.tsx
@@ -31,6 +31,7 @@ export default function EarnTri({ stablePoolsOrder }: { stablePoolsOrder: number
                 key={farm.ID}
                 apr={farm.apr}
                 apr2={farm.apr2}
+                nonTriAPRs={farm.nonTriAPRs}
                 chefVersion={farm.chefVersion}
                 isPeriodFinished={farm.isPeriodFinished}
                 tokens={farm.tokens}

--- a/src/pages/EarnTri/useFarmsSortAndFilter.tsx
+++ b/src/pages/EarnTri/useFarmsSortAndFilter.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useEffect } from 'react'
-import { isEqual } from 'lodash'
+import _, { isEqual } from 'lodash'
 import { useFarms } from '../../state/stake/apr'
 import { StakingTri } from '../../state/stake/stake-constants'
 import { useIsFilterActiveFarms } from '../../state/user/hooks'
@@ -49,15 +49,15 @@ export default function useFarmsSortAndFilter({ poolsOrder, legacyPoolsOrder }: 
   const farmArrsInOrder = useMemo((): StakingTri[] => {
     switch (sortBy) {
       case SortingType.default:
-        return poolsOrder.map((index: number) => allFarmArrs[index])
+        return poolsOrder.map(index => allFarmArrs[index])
       case SortingType.liquidity:
-        return isSortDescending
-          ? farmArrs.sort((a, b) => (a.totalStakedInUSD < b.totalStakedInUSD ? 1 : -1))
-          : farmArrs.sort((a, b) => (a.totalStakedInUSD > b.totalStakedInUSD ? 1 : -1))
+        return _.orderBy(farmArrs, 'totalStakedInUSD', isSortDescending ? 'desc' : 'asc')
       case SortingType.totalApr:
-        return isSortDescending
-          ? farmArrs.sort((a, b) => (a.apr + a.apr2 < b.apr + b.apr2 ? 1 : -1))
-          : farmArrs.sort((a, b) => (a.apr + a.apr2 > b.apr + b.apr2 ? 1 : -1))
+        return _.orderBy(
+          farmArrs,
+          ({ apr: triAPR, nonTriAPRs }) => (nonTriAPRs ?? []).reduce((acc: number, { apr }) => acc + apr, triAPR ?? 0),
+          isSortDescending ? 'desc' : 'asc'
+        )
     }
   }, [allFarmArrs, farmArrs, isSortDescending, poolsOrder, sortBy])
   const nonDualRewardPools = farmArrsInOrder.filter(farm => !farm.doubleRewards && !farm.noTriRewards)

--- a/src/pages/EarnTri/useFarmsSortAndFilter.tsx
+++ b/src/pages/EarnTri/useFarmsSortAndFilter.tsx
@@ -55,7 +55,7 @@ export default function useFarmsSortAndFilter({ poolsOrder, legacyPoolsOrder }: 
       case SortingType.totalApr:
         return _.orderBy(
           farmArrs,
-          ({ apr: triAPR, nonTriAPRs }) => (nonTriAPRs ?? []).reduce((acc: number, { apr }) => acc + apr, triAPR ?? 0),
+          ({ apr: triAPR, nonTriAPRs }) => nonTriAPRs.reduce((acc: number, { apr }) => acc + apr, triAPR ?? 0),
           isSortDescending ? 'desc' : 'asc'
         )
     }

--- a/src/state/stake/__tests__/__snapshots__/stake-constants.test.ts.snap
+++ b/src/state/stake/__tests__/__snapshots__/stake-constants.test.ts.snap
@@ -5,7 +5,6 @@ Object {
   "ID": 0,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 0,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -61,6 +60,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0x63da4DB6Ef4e7C62168aB03982399F9588fCd198",
   "noTriRewards": false,
+  "nonTriAPRs": Array [],
   "poolId": 0,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -84,6 +84,7 @@ Object {
     },
   },
   "rewarderAddress": "",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -153,7 +154,6 @@ Object {
   "ID": 1,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 0,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -209,6 +209,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0x20F8AeFB5697B77E0BB835A8518BE70775cdA1b0",
   "noTriRewards": false,
+  "nonTriAPRs": Array [],
   "poolId": 1,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -232,6 +233,7 @@ Object {
     },
   },
   "rewarderAddress": "",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -301,7 +303,6 @@ Object {
   "ID": 2,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 0,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -357,6 +358,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0x03B666f3488a7992b2385B12dF7f35156d7b29cD",
   "noTriRewards": false,
+  "nonTriAPRs": Array [],
   "poolId": 2,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -380,6 +382,7 @@ Object {
     },
   },
   "rewarderAddress": "",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -449,7 +452,6 @@ Object {
   "ID": 3,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 0,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -505,6 +507,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0x2fe064B6c7D274082aa5d2624709bC9AE7D16C77",
   "noTriRewards": false,
+  "nonTriAPRs": Array [],
   "poolId": 3,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -528,6 +531,7 @@ Object {
     },
   },
   "rewarderAddress": "",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -597,7 +601,6 @@ Object {
   "ID": 4,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 0,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -653,6 +656,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0xbc8A244e8fb683ec1Fd6f88F3cc6E565082174Eb",
   "noTriRewards": false,
+  "nonTriAPRs": Array [],
   "poolId": 4,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -676,6 +680,7 @@ Object {
     },
   },
   "rewarderAddress": "",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -745,7 +750,6 @@ Object {
   "ID": 5,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 0,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -801,6 +805,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0x84b123875F0F36B966d0B6Ca14b31121bd9676AD",
   "noTriRewards": false,
+  "nonTriAPRs": Array [],
   "poolId": 5,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -824,6 +829,7 @@ Object {
     },
   },
   "rewarderAddress": "",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -893,7 +899,6 @@ Object {
   "ID": 6,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 0,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -949,6 +954,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0x5eeC60F348cB1D661E4A5122CF4638c7DB7A886e",
   "noTriRewards": false,
+  "nonTriAPRs": Array [],
   "poolId": 6,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -972,6 +978,7 @@ Object {
     },
   },
   "rewarderAddress": "",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -1041,7 +1048,6 @@ Object {
   "ID": 7,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 1,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -1097,6 +1103,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0x5eeC60F348cB1D661E4A5122CF4638c7DB7A886e",
   "noTriRewards": false,
+  "nonTriAPRs": Array [],
   "poolId": 0,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -1120,6 +1127,7 @@ Object {
     },
   },
   "rewarderAddress": "0x94669d7a170bfe62FAc297061663e0B48C63B9B5",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -1189,7 +1197,6 @@ Object {
   "ID": 8,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 1,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -1245,6 +1252,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0xd1654a7713617d41A8C9530Fb9B948d00e162194",
   "noTriRewards": false,
+  "nonTriAPRs": Array [],
   "poolId": 1,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -1268,6 +1276,7 @@ Object {
     },
   },
   "rewarderAddress": "0x78EdEeFdF8c3ad827228d07018578E89Cf159Df1",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -1337,7 +1346,6 @@ Object {
   "ID": 9,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 1,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -1393,6 +1401,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0xdF8CbF89ad9b7dAFdd3e37acEc539eEcC8c47914",
   "noTriRewards": false,
+  "nonTriAPRs": Array [],
   "poolId": 2,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -1416,6 +1425,7 @@ Object {
     },
   },
   "rewarderAddress": "0x89F6628927fdFA2592E016Ba5B14389a4b08D681",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -1485,7 +1495,6 @@ Object {
   "ID": 10,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 1,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -1541,6 +1550,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0xa9eded3E339b9cd92bB6DEF5c5379d678131fF90",
   "noTriRewards": false,
+  "nonTriAPRs": Array [],
   "poolId": 3,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -1564,6 +1574,7 @@ Object {
     },
   },
   "rewarderAddress": "0x17d1597ec86fD6aecbfE0F32Ab2F2aD9c37E6750",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -1633,7 +1644,6 @@ Object {
   "ID": 11,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 1,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -1689,6 +1699,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0x61C9E05d1Cdb1b70856c7a2c53fA9c220830633c",
   "noTriRewards": false,
+  "nonTriAPRs": Array [],
   "poolId": 4,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -1712,6 +1723,7 @@ Object {
     },
   },
   "rewarderAddress": "",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -1781,7 +1793,6 @@ Object {
   "ID": 12,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 1,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -1837,6 +1848,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0x6443532841a5279cb04420E61Cf855cBEb70dc8C",
   "noTriRewards": false,
+  "nonTriAPRs": Array [],
   "poolId": 5,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -1860,6 +1872,7 @@ Object {
     },
   },
   "rewarderAddress": "",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -1929,7 +1942,6 @@ Object {
   "ID": 13,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 1,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -1985,6 +1997,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0x7be4a49AA41B34db70e539d4Ae43c7fBDf839DfA",
   "noTriRewards": false,
+  "nonTriAPRs": Array [],
   "poolId": 6,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -2008,6 +2021,7 @@ Object {
     },
   },
   "rewarderAddress": "",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -2077,7 +2091,6 @@ Object {
   "ID": 14,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 1,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -2133,6 +2146,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0x3dC236Ea01459F57EFc737A12BA3Bb5F3BFfD071",
   "noTriRewards": false,
+  "nonTriAPRs": Array [],
   "poolId": 7,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -2156,6 +2170,7 @@ Object {
     },
   },
   "rewarderAddress": "",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -2225,7 +2240,6 @@ Object {
   "ID": 15,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 1,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -2281,6 +2295,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0x48887cEEA1b8AD328d5254BeF774Be91B90FaA09",
   "noTriRewards": false,
+  "nonTriAPRs": Array [],
   "poolId": 8,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -2304,6 +2319,7 @@ Object {
     },
   },
   "rewarderAddress": "0x42b950FB4dd822ef04C4388450726EFbF1C3CF63",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -2373,7 +2389,6 @@ Object {
   "ID": 16,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 1,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -2429,6 +2444,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0xd62f9ec4C4d323A0C111d5e78b77eA33A2AA862f",
   "noTriRewards": true,
+  "nonTriAPRs": Array [],
   "poolId": 9,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -2452,6 +2468,7 @@ Object {
     },
   },
   "rewarderAddress": "0x9847F7e33CCbC0542b05d15c5cf3aE2Ae092C057",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -2521,7 +2538,6 @@ Object {
   "ID": 17,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 1,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -2577,6 +2593,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0xdDAdf88b007B95fEb42DDbd110034C9a8e9746F2",
   "noTriRewards": true,
+  "nonTriAPRs": Array [],
   "poolId": 10,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -2600,6 +2617,7 @@ Object {
     },
   },
   "rewarderAddress": "0xbbE41F699B0fB747cd4bA21067F6b27e0698Bc30",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -2669,7 +2687,6 @@ Object {
   "ID": 18,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 1,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -2725,6 +2742,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0x5913f644A10d98c79F2e0b609988640187256373",
   "noTriRewards": false,
+  "nonTriAPRs": Array [],
   "poolId": 11,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -2748,6 +2766,7 @@ Object {
     },
   },
   "rewarderAddress": "0x7B9e31BbEdbfdc99e3CC8b879b9a3B1e379Ce530",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -2817,7 +2836,6 @@ Object {
   "ID": 19,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 1,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -2873,6 +2891,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0x47924Ae4968832984F4091EEC537dfF5c38948a4",
   "noTriRewards": false,
+  "nonTriAPRs": Array [],
   "poolId": 12,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -2896,6 +2915,7 @@ Object {
     },
   },
   "rewarderAddress": "0xf267212F1D8888e0eD20BbB0c7C87A089cDe6E88",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -2965,7 +2985,6 @@ Object {
   "ID": 20,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 1,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -3021,6 +3040,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0xb419ff9221039Bdca7bb92A131DD9CF7DEb9b8e5",
   "noTriRewards": true,
+  "nonTriAPRs": Array [],
   "poolId": 13,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -3044,6 +3064,7 @@ Object {
     },
   },
   "rewarderAddress": "0xb84293D04137c9061afe34118Dac9931df153826",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -3113,7 +3134,6 @@ Object {
   "ID": 21,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 1,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -3169,6 +3189,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0xFBc4C42159A5575a772BebA7E3BF91DB508E127a",
   "noTriRewards": true,
+  "nonTriAPRs": Array [],
   "poolId": 14,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -3192,6 +3213,7 @@ Object {
     },
   },
   "rewarderAddress": "0x028Fbc4BB5787e340524EF41d95875Ac2C382101",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -3261,7 +3283,6 @@ Object {
   "ID": 22,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 1,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -3317,6 +3338,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0x7B273238C6DD0453C160f305df35c350a123E505",
   "noTriRewards": true,
+  "nonTriAPRs": Array [],
   "poolId": 15,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -3340,6 +3362,7 @@ Object {
     },
   },
   "rewarderAddress": "0xDAc58A615E2A1a94D7fb726a96C273c057997D50",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -3409,7 +3432,6 @@ Object {
   "ID": 23,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 1,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -3465,6 +3487,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0x6277f94a69Df5df0Bc58b25917B9ECEFBf1b846A",
   "noTriRewards": false,
+  "nonTriAPRs": Array [],
   "poolId": 16,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -3488,6 +3511,7 @@ Object {
     },
   },
   "rewarderAddress": "0x170431D69544a1BC97855C6564E8460d39508844",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -3557,7 +3581,6 @@ Object {
   "ID": 24,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 1,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -3613,6 +3636,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0xadAbA7E2bf88Bd10ACb782302A568294566236dC",
   "noTriRewards": true,
+  "nonTriAPRs": Array [],
   "poolId": 17,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -3636,6 +3660,7 @@ Object {
     },
   },
   "rewarderAddress": "0xABE01A6b6922130C982E221681EB4C4aD07A21dA",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -3700,12 +3725,1501 @@ Object {
 }
 `;
 
+exports[`stake-constants.ts Aurora Pools: Aurora Pool [ID: 25] 1`] = `
+Object {
+  "ID": 25,
+  "allocPoint": 1,
+  "apr": 0,
+  "chefVersion": 1,
+  "doubleRewardAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "doubleRewardToken": Token {
+    "address": "0x0000000000000000000000000000000000000000",
+    "chainId": 1313161554,
+    "decimals": 18,
+    "name": "ZERO",
+    "symbol": "ZERO",
+  },
+  "doubleRewards": false,
+  "earnedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "inStaging": true,
+  "isPeriodFinished": false,
+  "lpAddress": "0x5EB99863f7eFE88c447Bc9D52AA800421b1de6c9",
+  "noTriRewards": false,
+  "nonTriAPRs": Array [],
+  "poolId": 18,
+  "rewardRate": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "rewarderAddress": "",
+  "stableSwapPoolName": "USDC_USDT",
+  "stakedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "stakingRewardAddress": "0x3838956710bcc9D122Dd23863a0549ca8D5675D6",
+  "tokens": Array [
+    Token {
+      "address": "0xB12BFcA5A55806AaF64E99521918A4bf0fC40802",
+      "chainId": 1313161554,
+      "decimals": 6,
+      "name": "USD Coin",
+      "symbol": "USDC",
+    },
+    Token {
+      "address": "0x4988a896b1227218e4A686fdE5EabdcAbd91571f",
+      "chainId": 1313161554,
+      "decimals": 6,
+      "name": "Tether USD",
+      "symbol": "USDT",
+    },
+  ],
+  "totalRewardRate": 1,
+  "totalStakedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "totalStakedInUSD": 0,
+}
+`;
+
+exports[`stake-constants.ts Aurora Pools: Aurora Pool [ID: 26] 1`] = `
+Object {
+  "ID": 26,
+  "allocPoint": 1,
+  "apr": 0,
+  "chefVersion": 1,
+  "doubleRewardAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "doubleRewardToken": Token {
+    "address": "0x0000000000000000000000000000000000000000",
+    "chainId": 1313161554,
+    "decimals": 18,
+    "name": "ZERO",
+    "symbol": "ZERO",
+  },
+  "doubleRewards": false,
+  "earnedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "inStaging": false,
+  "isPeriodFinished": false,
+  "lpAddress": "0x5E74D85311fe2409c341Ce49Ce432BB950D221DE",
+  "noTriRewards": false,
+  "nonTriAPRs": Array [],
+  "poolId": 19,
+  "rewardRate": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "rewarderAddress": "",
+  "stableSwapPoolName": null,
+  "stakedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "stakingRewardAddress": "0x3838956710bcc9D122Dd23863a0549ca8D5675D6",
+  "tokens": Array [
+    Token {
+      "address": "0x68e401B61eA53889505cc1366710f733A60C2d41",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "Shitzu",
+      "symbol": "SHITZU",
+    },
+    Token {
+      "address": "0xB12BFcA5A55806AaF64E99521918A4bf0fC40802",
+      "chainId": 1313161554,
+      "decimals": 6,
+      "name": "USD Coin",
+      "symbol": "USDC",
+    },
+  ],
+  "totalRewardRate": 1,
+  "totalStakedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "totalStakedInUSD": 0,
+}
+`;
+
+exports[`stake-constants.ts Aurora Pools: Aurora Pool [ID: 27] 1`] = `
+Object {
+  "ID": 27,
+  "allocPoint": 1,
+  "apr": 0,
+  "chefVersion": 1,
+  "doubleRewardAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "doubleRewardToken": Token {
+    "address": "0xdcD6D4e2B3e1D1E1E6Fa8C21C8A323DcbecfF970",
+    "chainId": 1313161554,
+    "decimals": 18,
+    "name": "Rose Token",
+    "symbol": "ROSE",
+  },
+  "doubleRewards": true,
+  "earnedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "inStaging": false,
+  "isPeriodFinished": false,
+  "lpAddress": "0xbe753E99D0dBd12FB39edF9b884eBF3B1B09f26C",
+  "noTriRewards": false,
+  "nonTriAPRs": Array [],
+  "poolId": 20,
+  "rewardRate": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "rewarderAddress": "0xfe9B7A3bf38cE0CA3D5fA25d371Ff5C6598663d4",
+  "stableSwapPoolName": null,
+  "stakedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "stakingRewardAddress": "0x3838956710bcc9D122Dd23863a0549ca8D5675D6",
+  "tokens": Array [
+    Token {
+      "address": "0xC42C30aC6Cc15faC9bD938618BcaA1a1FaE8501d",
+      "chainId": 1313161554,
+      "decimals": 24,
+      "name": "Wrapped Near",
+      "symbol": "wNEAR",
+    },
+    Token {
+      "address": "0xdcD6D4e2B3e1D1E1E6Fa8C21C8A323DcbecfF970",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "Rose Token",
+      "symbol": "ROSE",
+    },
+  ],
+  "totalRewardRate": 1,
+  "totalStakedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "totalStakedInUSD": 0,
+}
+`;
+
+exports[`stake-constants.ts Aurora Pools: Aurora Pool [ID: 28] 1`] = `
+Object {
+  "ID": 28,
+  "allocPoint": 1,
+  "apr": 0,
+  "chefVersion": 1,
+  "doubleRewardAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "doubleRewardToken": Token {
+    "address": "0xdcD6D4e2B3e1D1E1E6Fa8C21C8A323DcbecfF970",
+    "chainId": 1313161554,
+    "decimals": 18,
+    "name": "Rose Token",
+    "symbol": "ROSE",
+  },
+  "doubleRewards": true,
+  "earnedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "inStaging": false,
+  "isPeriodFinished": false,
+  "lpAddress": "0xbC0e71aE3Ef51ae62103E003A9Be2ffDe8421700",
+  "noTriRewards": false,
+  "nonTriAPRs": Array [],
+  "poolId": 21,
+  "rewardRate": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "rewarderAddress": "0x87a03aFA70302a5a0F6156eBEd27f230ABF0e69C",
+  "stableSwapPoolName": null,
+  "stakedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "stakingRewardAddress": "0x3838956710bcc9D122Dd23863a0549ca8D5675D6",
+  "tokens": Array [
+    Token {
+      "address": "0xC42C30aC6Cc15faC9bD938618BcaA1a1FaE8501d",
+      "chainId": 1313161554,
+      "decimals": 24,
+      "name": "Wrapped Near",
+      "symbol": "wNEAR",
+    },
+    Token {
+      "address": "0x19cc40283B057D6608C22F1D20F17e16C245642E",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "Rose USD",
+      "symbol": "RUSD",
+    },
+  ],
+  "totalRewardRate": 1,
+  "totalStakedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "totalStakedInUSD": 0,
+}
+`;
+
+exports[`stake-constants.ts Aurora Pools: Aurora Pool [ID: 29] 1`] = `
+Object {
+  "ID": 29,
+  "allocPoint": 1,
+  "apr": 0,
+  "chefVersion": 1,
+  "doubleRewardAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "doubleRewardToken": Token {
+    "address": "0x918dBe087040A41b786f0Da83190c293DAe24749",
+    "chainId": 1313161554,
+    "decimals": 24,
+    "name": "LiNEAR",
+    "symbol": "LINEAR",
+  },
+  "doubleRewards": true,
+  "earnedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "inStaging": false,
+  "isPeriodFinished": false,
+  "lpAddress": "0xbceA13f9125b0E3B66e979FedBCbf7A4AfBa6fd1",
+  "noTriRewards": false,
+  "nonTriAPRs": Array [],
+  "poolId": 22,
+  "rewardRate": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "rewarderAddress": "0x1616B20534d1d1d731C31Ca325F4e909b8f3E0f0",
+  "stableSwapPoolName": null,
+  "stakedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "stakingRewardAddress": "0x3838956710bcc9D122Dd23863a0549ca8D5675D6",
+  "tokens": Array [
+    Token {
+      "address": "0xC42C30aC6Cc15faC9bD938618BcaA1a1FaE8501d",
+      "chainId": 1313161554,
+      "decimals": 24,
+      "name": "Wrapped Near",
+      "symbol": "wNEAR",
+    },
+    Token {
+      "address": "0x918dBe087040A41b786f0Da83190c293DAe24749",
+      "chainId": 1313161554,
+      "decimals": 24,
+      "name": "LiNEAR",
+      "symbol": "LINEAR",
+    },
+  ],
+  "totalRewardRate": 1,
+  "totalStakedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "totalStakedInUSD": 0,
+}
+`;
+
+exports[`stake-constants.ts Aurora Pools: Aurora Pool [ID: 30] 1`] = `
+Object {
+  "ID": 30,
+  "allocPoint": 1,
+  "apr": 0,
+  "chefVersion": 1,
+  "doubleRewardAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "doubleRewardToken": Token {
+    "address": "0x9f1F933C660a1DC856F0E0Fe058435879c5CCEf0",
+    "chainId": 1313161554,
+    "decimals": 18,
+    "name": "Bastion",
+    "symbol": "BSTN",
+  },
+  "doubleRewards": true,
+  "earnedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "inStaging": false,
+  "isPeriodFinished": false,
+  "lpAddress": "0xBBf3D4281F10E537d5b13CA80bE22362310b2bf9",
+  "noTriRewards": false,
+  "nonTriAPRs": Array [],
+  "poolId": 23,
+  "rewardRate": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "rewarderAddress": "0xDc6d09f5CC085E29972d192cB3AdCDFA6495a741",
+  "stableSwapPoolName": null,
+  "stakedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "stakingRewardAddress": "0x3838956710bcc9D122Dd23863a0549ca8D5675D6",
+  "tokens": Array [
+    Token {
+      "address": "0xC42C30aC6Cc15faC9bD938618BcaA1a1FaE8501d",
+      "chainId": 1313161554,
+      "decimals": 24,
+      "name": "Wrapped Near",
+      "symbol": "wNEAR",
+    },
+    Token {
+      "address": "0x9f1F933C660a1DC856F0E0Fe058435879c5CCEf0",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "Bastion",
+      "symbol": "BSTN",
+    },
+  ],
+  "totalRewardRate": 1,
+  "totalStakedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "totalStakedInUSD": 0,
+}
+`;
+
+exports[`stake-constants.ts Aurora Pools: Aurora Pool [ID: 31] 1`] = `
+Object {
+  "ID": 31,
+  "allocPoint": 1,
+  "apr": 0,
+  "chefVersion": 1,
+  "doubleRewardAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "doubleRewardToken": Token {
+    "address": "0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79",
+    "chainId": 1313161554,
+    "decimals": 18,
+    "name": "Aurora",
+    "symbol": "AURORA",
+  },
+  "doubleRewards": true,
+  "earnedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "inStaging": false,
+  "isPeriodFinished": false,
+  "lpAddress": "0x1e0e812FBcd3EB75D8562AD6F310Ed94D258D008",
+  "noTriRewards": false,
+  "nonTriAPRs": Array [],
+  "poolId": 24,
+  "rewardRate": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "rewarderAddress": "0x34c58E960b80217fA3e0323d37563c762a131AD9",
+  "stableSwapPoolName": null,
+  "stakedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "stakingRewardAddress": "0x3838956710bcc9D122Dd23863a0549ca8D5675D6",
+  "tokens": Array [
+    Token {
+      "address": "0xC42C30aC6Cc15faC9bD938618BcaA1a1FaE8501d",
+      "chainId": 1313161554,
+      "decimals": 24,
+      "name": "Wrapped Near",
+      "symbol": "wNEAR",
+    },
+    Token {
+      "address": "0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "Aurora",
+      "symbol": "AURORA",
+    },
+  ],
+  "totalRewardRate": 1,
+  "totalStakedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "totalStakedInUSD": 0,
+}
+`;
+
+exports[`stake-constants.ts Aurora Pools: Aurora Pool [ID: 32] 1`] = `
+Object {
+  "ID": 32,
+  "allocPoint": 1,
+  "apr": 0,
+  "chefVersion": 1,
+  "doubleRewardAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "doubleRewardToken": Token {
+    "address": "0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79",
+    "chainId": 1313161554,
+    "decimals": 18,
+    "name": "Aurora",
+    "symbol": "AURORA",
+  },
+  "doubleRewards": true,
+  "earnedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "inStaging": false,
+  "isPeriodFinished": false,
+  "lpAddress": "0x20F8AeFB5697B77E0BB835A8518BE70775cdA1b0",
+  "noTriRewards": false,
+  "nonTriAPRs": Array [],
+  "poolId": 25,
+  "rewardRate": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "rewarderAddress": "0x84C8B673ddBF0F647c350dEd488787d3102ebfa3",
+  "stableSwapPoolName": null,
+  "stakedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "stakingRewardAddress": "0x3838956710bcc9D122Dd23863a0549ca8D5675D6",
+  "tokens": Array [
+    Token {
+      "address": "0xC42C30aC6Cc15faC9bD938618BcaA1a1FaE8501d",
+      "chainId": 1313161554,
+      "decimals": 24,
+      "name": "Wrapped Near",
+      "symbol": "wNEAR",
+    },
+    Token {
+      "address": "0xB12BFcA5A55806AaF64E99521918A4bf0fC40802",
+      "chainId": 1313161554,
+      "decimals": 6,
+      "name": "USD Coin",
+      "symbol": "USDC",
+    },
+  ],
+  "totalRewardRate": 1,
+  "totalStakedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "totalStakedInUSD": 0,
+}
+`;
+
+exports[`stake-constants.ts Aurora Pools: Aurora Pool [ID: 33] 1`] = `
+Object {
+  "ID": 33,
+  "allocPoint": 1,
+  "apr": 0,
+  "chefVersion": 1,
+  "doubleRewardAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "doubleRewardToken": Token {
+    "address": "0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79",
+    "chainId": 1313161554,
+    "decimals": 18,
+    "name": "Aurora",
+    "symbol": "AURORA",
+  },
+  "doubleRewards": true,
+  "earnedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "inStaging": false,
+  "isPeriodFinished": false,
+  "lpAddress": "0x03B666f3488a7992b2385B12dF7f35156d7b29cD",
+  "noTriRewards": false,
+  "nonTriAPRs": Array [],
+  "poolId": 26,
+  "rewardRate": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "rewarderAddress": "0x4e0152b260319e5131f853AeCB92c8f992AA0c97",
+  "stableSwapPoolName": null,
+  "stakedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "stakingRewardAddress": "0x3838956710bcc9D122Dd23863a0549ca8D5675D6",
+  "tokens": Array [
+    Token {
+      "address": "0xC42C30aC6Cc15faC9bD938618BcaA1a1FaE8501d",
+      "chainId": 1313161554,
+      "decimals": 24,
+      "name": "Wrapped Near",
+      "symbol": "wNEAR",
+    },
+    Token {
+      "address": "0x4988a896b1227218e4A686fdE5EabdcAbd91571f",
+      "chainId": 1313161554,
+      "decimals": 6,
+      "name": "Tether USD",
+      "symbol": "USDT",
+    },
+  ],
+  "totalRewardRate": 1,
+  "totalStakedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "totalStakedInUSD": 0,
+}
+`;
+
+exports[`stake-constants.ts Aurora Pools: Aurora Pool [ID: 34] 1`] = `
+Object {
+  "ID": 34,
+  "allocPoint": 1,
+  "apr": 0,
+  "chefVersion": 1,
+  "doubleRewardAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "doubleRewardToken": Token {
+    "address": "0xE4eB03598f4DCAB740331fa432f4b85FF58AA97E",
+    "chainId": 1313161554,
+    "decimals": 18,
+    "name": "KillSwitchToken",
+    "symbol": "KSW",
+  },
+  "doubleRewards": false,
+  "earnedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "inStaging": false,
+  "isPeriodFinished": false,
+  "lpAddress": "0x29C160d2EF4790F9A23B813e7544D99E539c28Ba",
+  "noTriRewards": true,
+  "nonTriAPRs": Array [],
+  "poolId": 27,
+  "rewardRate": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "rewarderAddress": "0x0Cc7e9D333bDAb07b2C8d41363C72c472B7E9594",
+  "stableSwapPoolName": null,
+  "stakedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "stakingRewardAddress": "0x3838956710bcc9D122Dd23863a0549ca8D5675D6",
+  "tokens": Array [
+    Token {
+      "address": "0xE4eB03598f4DCAB740331fa432f4b85FF58AA97E",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "KillSwitchToken",
+      "symbol": "KSW",
+    },
+    Token {
+      "address": "0xC42C30aC6Cc15faC9bD938618BcaA1a1FaE8501d",
+      "chainId": 1313161554,
+      "decimals": 24,
+      "name": "Wrapped Near",
+      "symbol": "wNEAR",
+    },
+  ],
+  "totalRewardRate": 1,
+  "totalStakedAmount": TokenAmount {
+    "currency": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+    "denominator": JSBI [
+      660865024,
+      931322574,
+    ],
+    "numerator": JSBI [],
+    "token": Token {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": 1313161554,
+      "decimals": 18,
+      "name": "ZERO",
+      "symbol": "ZERO",
+    },
+  },
+  "totalStakedInUSD": 0,
+}
+`;
+
 exports[`stake-constants.ts Polygon Pools: Polygon Pool [ID: 0] 1`] = `
 Object {
   "ID": 0,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 0,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -3761,6 +5275,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0xd6f922f6eB4dfa47f53C038c7dE9bE614a49257f",
   "noTriRewards": false,
+  "nonTriAPRs": Array [],
   "poolId": 0,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -3784,6 +5299,7 @@ Object {
     },
   },
   "rewarderAddress": "",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",
@@ -3853,7 +5369,6 @@ Object {
   "ID": 1,
   "allocPoint": 1,
   "apr": 0,
-  "apr2": 0,
   "chefVersion": 0,
   "doubleRewardAmount": TokenAmount {
     "currency": Token {
@@ -3909,6 +5424,7 @@ Object {
   "isPeriodFinished": false,
   "lpAddress": "0x76F4128B11f429289499BA29518Ef7E5b26025B6",
   "noTriRewards": false,
+  "nonTriAPRs": Array [],
   "poolId": 1,
   "rewardRate": TokenAmount {
     "currency": Token {
@@ -3932,6 +5448,7 @@ Object {
     },
   },
   "rewarderAddress": "",
+  "stableSwapPoolName": null,
   "stakedAmount": TokenAmount {
     "currency": Token {
       "address": "0x0000000000000000000000000000000000000000",

--- a/src/state/stake/__tests__/stake-constants.test.ts
+++ b/src/state/stake/__tests__/stake-constants.test.ts
@@ -1,15 +1,11 @@
-import { ChainId } from '@trisolaris/sdk';
-import { STAKING } from '../stake-constants';
+import { ChainId } from '@trisolaris/sdk'
+import { STAKING } from '../stake-constants'
 
 describe('stake-constants.ts', () => {
-    test('Polygon Pools', () => {
-        STAKING[ChainId.POLYGON].forEach(pool =>
-            expect(pool).toMatchSnapshot(`Polygon Pool [ID: ${pool.ID}]`)
-        )
-    })
-    test('Aurora Pools', () => {
-        STAKING[ChainId.AURORA].forEach(pool =>
-            expect(pool).toMatchSnapshot(`Aurora Pool [ID: ${pool.ID}]`)
-        )
-    })
-});
+  test('Polygon Pools', () => {
+    STAKING[ChainId.POLYGON].forEach(pool => expect(pool).toMatchSnapshot(`Polygon Pool [ID: ${pool.ID}]`))
+  })
+  test('Aurora Pools', () => {
+    STAKING[ChainId.AURORA].forEach(pool => expect(pool).toMatchSnapshot(`Aurora Pool [ID: ${pool.ID}]`))
+  })
+})

--- a/src/state/stake/stake-constants.ts
+++ b/src/state/stake/stake-constants.ts
@@ -66,7 +66,7 @@ export type StakingTriFarms = {
   rewardRate: TokenAmount
   apr: number
   apr2: number
-  nonTriAPRs?: NonTriAPR[]
+  nonTriAPRs: NonTriAPR[]
   chefVersion: ChefVersions
   doubleRewards: boolean
   inStaging: boolean
@@ -85,7 +85,7 @@ export interface ExternalInfo {
   allocPoint: number
   apr: number
   apr2: number
-  nonTriAPRs?: NonTriAPR[]
+  nonTriAPRs: NonTriAPR[]
 }
 
 export const dummyToken = new Token(ChainId.AURORA, ZERO_ADDRESS, 18, 'ZERO', 'ZERO')

--- a/src/state/stake/stake-constants.ts
+++ b/src/state/stake/stake-constants.ts
@@ -65,7 +65,6 @@ export type StakingTriFarms = {
   // equivalent to percent of total supply * reward rate
   rewardRate: TokenAmount
   apr: number
-  apr2: number
   nonTriAPRs: NonTriAPR[]
   chefVersion: ChefVersions
   doubleRewards: boolean
@@ -84,7 +83,6 @@ export interface ExternalInfo {
   totalRewardRate: number
   allocPoint: number
   apr: number
-  apr2: number
   nonTriAPRs: NonTriAPR[]
 }
 
@@ -112,7 +110,6 @@ const NULL_POOL: StakingTri = {
   totalRewardRate: 1,
   rewardRate: dummyAmount,
   apr: 0,
-  apr2: 0,
   nonTriAPRs: [],
   chefVersion: ChefVersions.V1,
   doubleRewards: false,

--- a/src/state/stake/stake-constants.ts
+++ b/src/state/stake/stake-constants.ts
@@ -41,7 +41,7 @@ export enum ChefVersions {
 }
 
 export type StakingTri = StakingTriStakedAmounts & StakingTriFarms
-
+export type NonTriAPR = { address: string; apr: number }
 export type StakingTriStakedAmounts = {
   ID: number
   stakedAmount: TokenAmount | null
@@ -66,6 +66,7 @@ export type StakingTriFarms = {
   rewardRate: TokenAmount
   apr: number
   apr2: number
+  nonTriAPRs?: NonTriAPR[]
   chefVersion: ChefVersions
   doubleRewards: boolean
   inStaging: boolean
@@ -84,6 +85,7 @@ export interface ExternalInfo {
   allocPoint: number
   apr: number
   apr2: number
+  nonTriAPRs?: NonTriAPR[]
 }
 
 export const dummyToken = new Token(ChainId.AURORA, ZERO_ADDRESS, 18, 'ZERO', 'ZERO')
@@ -111,6 +113,7 @@ const NULL_POOL: StakingTri = {
   rewardRate: dummyAmount,
   apr: 0,
   apr2: 0,
+  nonTriAPRs: [],
   chefVersion: ChefVersions.V1,
   doubleRewards: false,
   inStaging: false,

--- a/src/state/stake/useFarmsAPI.ts
+++ b/src/state/stake/useFarmsAPI.ts
@@ -36,7 +36,7 @@ export function useFarmsAPI(): StakingTriFarms[] {
       doubleRewardToken,
       stableSwapPoolName
     } = activeFarms[index]
-    const { totalStakedInUSD, totalRewardRate, apr, apr2, nonTriAPRs } = stakingInfoData?.[index] ?? {}
+    const { totalStakedInUSD, totalRewardRate, apr, apr2, nonTriAPRs = [] } = stakingInfoData?.[index] ?? {}
 
     return {
       ID,

--- a/src/state/stake/useFarmsAPI.ts
+++ b/src/state/stake/useFarmsAPI.ts
@@ -36,7 +36,7 @@ export function useFarmsAPI(): StakingTriFarms[] {
       doubleRewardToken,
       stableSwapPoolName
     } = activeFarms[index]
-    const { totalStakedInUSD, totalRewardRate, apr, apr2 } = stakingInfoData?.[index] ?? {}
+    const { totalStakedInUSD, totalRewardRate, apr, apr2, nonTriAPRs } = stakingInfoData?.[index] ?? {}
 
     return {
       ID,
@@ -60,7 +60,8 @@ export function useFarmsAPI(): StakingTriFarms[] {
       inStaging,
       noTriRewards,
       doubleRewardToken,
-      stableSwapPoolName
+      stableSwapPoolName,
+      nonTriAPRs
     }
   })
 

--- a/src/state/stake/useFarmsAPI.ts
+++ b/src/state/stake/useFarmsAPI.ts
@@ -36,7 +36,7 @@ export function useFarmsAPI(): StakingTriFarms[] {
       doubleRewardToken,
       stableSwapPoolName
     } = activeFarms[index]
-    const { totalStakedInUSD, totalRewardRate, apr, apr2, nonTriAPRs = [] } = stakingInfoData?.[index] ?? {}
+    const { totalStakedInUSD, totalRewardRate, apr, nonTriAPRs = [] } = stakingInfoData?.[index] ?? {}
 
     return {
       ID,
@@ -54,7 +54,6 @@ export function useFarmsAPI(): StakingTriFarms[] {
       totalRewardRate: Math.round(totalRewardRate ?? 0),
       rewardRate: tokenAmount,
       apr: Math.round(apr ?? 0),
-      apr2: Math.round(apr2 ?? 0),
       chefVersion,
       doubleRewards,
       inStaging,

--- a/src/state/stake/useFarmsAPI.ts
+++ b/src/state/stake/useFarmsAPI.ts
@@ -61,7 +61,7 @@ export function useFarmsAPI(): StakingTriFarms[] {
       noTriRewards,
       doubleRewardToken,
       stableSwapPoolName,
-      nonTriAPRs
+      nonTriAPRs: nonTriAPRs.map(data => ({ ...data, apr: Math.round(data.apr) }))
     }
   })
 

--- a/src/state/stake/user-farms.ts
+++ b/src/state/stake/user-farms.ts
@@ -72,7 +72,7 @@ export function useSingleFarm(version: number): StakingTri {
       JSBI.BigInt(earnedComplexRewardPool)
     )
 
-    const { totalStakedInUSD, totalRewardRate, apr, apr2 } = stakingInfoData[version]
+    const { totalStakedInUSD, totalRewardRate, apr } = stakingInfoData[version]
 
     return {
       ...activeFarms[version],
@@ -86,7 +86,6 @@ export function useSingleFarm(version: number): StakingTri {
       totalRewardRate: Math.round(totalRewardRate),
       rewardRate: tokenAmount,
       apr: Math.round(apr),
-      apr2: Math.round(apr2),
       chefVersion
     }
   }, [chainId, userInfo, pendingTri, pendingComplexRewards, pairState, tokens, tokenA, tokenB, latestBlock])

--- a/src/state/stake/user-stable-farms.ts
+++ b/src/state/stake/user-stable-farms.ts
@@ -64,7 +64,7 @@ export function useSingleStableFarm(version: number, stableSwapPoolName: StableS
       JSBI.BigInt(earnedComplexRewardPool)
     )
 
-    const { totalStakedInUSD, totalRewardRate, apr, apr2 } = stakingInfoData[version]
+    const { totalStakedInUSD, totalRewardRate, apr, nonTriAPRs } = stakingInfoData[version]
 
     return {
       ...activeFarms[version],
@@ -77,7 +77,7 @@ export function useSingleStableFarm(version: number, stableSwapPoolName: StableS
       totalRewardRate: Math.round(totalRewardRate),
       rewardRate: tokenAmount,
       apr: Math.round(apr),
-      apr2: Math.round(apr2),
+      nonTriAPRs: nonTriAPRs.map(data => ({ ...data, apr: Math.round(data.apr) })),
       chefVersion
     }
   }, [


### PR DESCRIPTION
- Created components for updated server response signature
  - removal of `apr2`
  - addition of `nonTriAPRs: [ { address: string, apr: number } ]`

- Created `src/components/earn/PoolCardTriRewardText.tsx`
  - When there is only TRI rewards, renders [TRI Icon][APR %]:
    - eg: <img width="402" alt="Screen Shot 2022-05-10 at 5 32 10 PM" src="https://user-images.githubusercontent.com/94581898/167746336-31a96f39-d2ff-422b-a7d8-3f94e8bf00bf.png">

  - When there is only 1 non-TRI reward, renders [Reward Token Icon][APR %]:
    - eg: <img width="388" alt="Screen Shot 2022-05-10 at 5 31 46 PM" src="https://user-images.githubusercontent.com/94581898/167746323-4b765881-e008-4ef2-a213-5cc41e98a13b.png">

  - When are >1 reward tokens, renders [...all reward token icons][Total APR %], and a mouseover showing breakdown
    - eg: 

https://user-images.githubusercontent.com/94581898/167746461-9fc706f2-1e1a-4a4a-83fc-48cda88ced1c.mov


