### PR TITLE
move WNEAR-XNL, GBA-USDT, WNEAR-SOLACE to legacy

### DIFF
--- a/src/pages/EarnTri/EarnTri.tsx
+++ b/src/pages/EarnTri/EarnTri.tsx
@@ -8,8 +8,8 @@ import { PoolSection, DataRow } from './EarnTri.styles'
 import EarnTriSortAndFilterContainer from '../../components/EarnTriSortAndFilter/EarnTriSortAndFilterContainer'
 import useFarmsSortAndFilter from './useFarmsSortAndFilter'
 
-const POOLS_ORDER = [32, 33, 5, 11, 31, 8, 30, 7, 0, 3, 4, 15, 17, 18, 19, 20, 21, 22, 23, 24, 26, 27, 28, 29, 34]
-const LEGACY_POOLS = [1, 2, 6, 16, 12, 13, 14, 9, 10]
+const POOLS_ORDER = [32, 33, 5, 11, 31, 8, 30, 7, 0, 3, 4, 15, 18, 19, 21, 23, 24, 26, 27, 28, 29, 34]
+const LEGACY_POOLS = [1, 2, 6, 16, 12, 13, 14, 9, 10, 20, 22, 17]
 const STABLE_POOLS = [35]
 
 const MemoizedPoolCardTRI = React.memo(PoolCardTRI)


### PR DESCRIPTION
move WNEAR-XNL, GBA-USDT, WNEAR-SOLACE to legacy

Note: APR's will display "-" when apr is dsabled.

<img width="774" alt="Screen Shot 2022-05-20 at 16 02 09" src="https://user-images.githubusercontent.com/96993065/169602751-88ddaa92-972a-49c1-b1b4-b1a51b32c189.png">
