### PR TITLE
Fix mobile ptri stake page display

### DIFF
--- a/src/pages/StakeTri/index.tsx
+++ b/src/pages/StakeTri/index.tsx
@@ -34,23 +34,33 @@ const StyledExternalLink = styled(ExternalLink)`
 `
 
 const StyledTextinfo = styled.div`
-  margin: 20px 0;
+  margin: 20px 0 10px;
 `
 
-const TopContainer = styled(AutoRow)`
+const TopContainer = styled.div`
   align-items: stretch;
   display: flex;
   justify-content: space-between;
   margin: 0;
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+  flex-direction:column;
+`};
 `
 
 const AboutContainer = styled(AutoColumn)`
   margin-right: 16px;
   flex: 1 40%;
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+  margin: 0 0 20px;
+  font-size: 14px;
+`};
 `
 
 const StatsBoxContainer = styled(AutoColumn)`
   flex: 1 50%;
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+  font-size: 14px;
+`};
 `
 
 function StakeTri() {


### PR DESCRIPTION
Changing layout and font-size for mobile viewports

Before:
<img width="402" alt="Screen Shot 2022-06-01 at 20 53 24" src="https://user-images.githubusercontent.com/96993065/171520172-56806d8b-c3e0-438d-8d04-b0e0fe25c6e8.png">


After:
<img width="458" alt="Screen Shot 2022-06-01 at 20 53 41" src="https://user-images.githubusercontent.com/96993065/171520180-cbe401d4-a58f-410e-a5bb-98a7c97319d6.png">
