### PR TITLE
B/hide legacy farms

### DIFF
--- a/src/pages/EarnTri/EarnTri.tsx
+++ b/src/pages/EarnTri/EarnTri.tsx
@@ -7,10 +7,13 @@ import { PoolSection, DataRow } from './EarnTri.styles'
 
 import EarnTriSortAndFilterContainer from '../../components/EarnTriSortAndFilter/EarnTriSortAndFilterContainer'
 import useFarmsSortAndFilter from './useFarmsSortAndFilter'
+import Toggle from '../../components/Toggle'
+import { useShowLegacyFarms, useToggleShowLegacyFarms } from '../../state/user/hooks'
 
 const MemoizedPoolCardTRI = React.memo(PoolCardTRI)
 
 export default function EarnTri() {
+  const [showLegacyFarms, toggleShowLegacyFarms] = [useShowLegacyFarms(), useToggleShowLegacyFarms()]
   const {
     activeFarmsFilter,
     dualRewardPools,
@@ -150,26 +153,33 @@ export default function EarnTri() {
         <AutoColumn gap="lg" style={{ width: '100%' }}>
           <DataRow style={{ alignItems: 'baseline' }}>
             <TYPE.mediumHeader style={{ marginTop: '0.5rem' }}>Legacy Pools</TYPE.mediumHeader>
+            <Toggle
+              customToggleText={{ on: 'Show', off: 'Hide' }}
+              isActive={showLegacyFarms}
+              toggle={toggleShowLegacyFarms}
+            />
           </DataRow>
-          <PoolSection>
-            {legacyFarms.map(farm => (
-              <MemoizedPoolCardTRI
-                key={farm.ID}
-                apr={farm.apr}
-                nonTriAPRs={farm.nonTriAPRs}
-                chefVersion={farm.chefVersion}
-                isLegacy={true}
-                isPeriodFinished={farm.isPeriodFinished}
-                tokens={farm.tokens}
-                totalStakedInUSD={farm.totalStakedInUSD}
-                version={farm.ID}
-                hasNonTriRewards={farm.hasNonTriRewards}
-                inStaging={farm.inStaging}
-                noTriRewards={farm.noTriRewards}
-                isStaking={isTokenAmountPositive(farm.stakedAmount)}
-              />
-            ))}
-          </PoolSection>
+          {showLegacyFarms ? (
+            <PoolSection>
+              {legacyFarms.map(farm => (
+                <MemoizedPoolCardTRI
+                  key={farm.ID}
+                  apr={farm.apr}
+                  nonTriAPRs={farm.nonTriAPRs}
+                  chefVersion={farm.chefVersion}
+                  isLegacy={true}
+                  isPeriodFinished={farm.isPeriodFinished}
+                  tokens={farm.tokens}
+                  totalStakedInUSD={farm.totalStakedInUSD}
+                  version={farm.ID}
+                  hasNonTriRewards={farm.hasNonTriRewards}
+                  inStaging={farm.inStaging}
+                  noTriRewards={farm.noTriRewards}
+                  isStaking={isTokenAmountPositive(farm.stakedAmount)}
+                />
+              ))}
+            </PoolSection>
+          ) : null}
         </AutoColumn>
       )}
     </>

--- a/src/pages/EarnTri/EarnTri.tsx
+++ b/src/pages/EarnTri/EarnTri.tsx
@@ -9,8 +9,16 @@ import EarnTriSortAndFilterContainer from '../../components/EarnTriSortAndFilter
 import useFarmsSortAndFilter from './useFarmsSortAndFilter'
 import Toggle from '../../components/Toggle'
 import { useShowLegacyFarms, useToggleShowLegacyFarms } from '../../state/user/hooks'
+import styled from 'styled-components'
 
 const MemoizedPoolCardTRI = React.memo(PoolCardTRI)
+
+const TitleRow = styled(DataRow)`
+  align-items: baseline;
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    flex-direction: row;
+  `};
+`
 
 export default function EarnTri() {
   const [showLegacyFarms, toggleShowLegacyFarms] = [useShowLegacyFarms(), useToggleShowLegacyFarms()]
@@ -151,14 +159,15 @@ export default function EarnTri() {
       </AutoColumn>
       {!hasSearchQuery && !activeFarmsFilter && (
         <AutoColumn gap="lg" style={{ width: '100%' }}>
-          <DataRow style={{ alignItems: 'baseline' }}>
+          <TitleRow>
             <TYPE.mediumHeader style={{ marginTop: '0.5rem' }}>Legacy Pools</TYPE.mediumHeader>
             <Toggle
               customToggleText={{ on: 'Show', off: 'Hide' }}
               isActive={showLegacyFarms}
               toggle={toggleShowLegacyFarms}
+              fontSize="12px"
             />
-          </DataRow>
+          </TitleRow>
           {showLegacyFarms ? (
             <PoolSection>
               {legacyFarms.map(farm => (

--- a/src/state/stake/useFarmContractsForVersion.ts
+++ b/src/state/stake/useFarmContractsForVersion.ts
@@ -6,12 +6,17 @@ import { useCallback, useMemo } from 'react'
 import { usePairs } from '../../data/Reserves'
 import { useActiveWeb3React } from '../../hooks'
 import { useBlockNumber } from '../application/hooks'
+import { useShowLegacyFarms } from '../user/hooks'
+import { LEGACY_POOLS } from '../../constants/farms'
 
 // gets the staking info from the network for the active chain id
 export function useFarmContractsForVersion(chefVersion: ChefVersions): StakingTriStakedAmounts[] {
   const { chainId, account } = useActiveWeb3React()
+  const showLegacyFarms = useShowLegacyFarms()
 
-  const activeFarms = STAKING[chainId ?? ChainId.AURORA]
+  const activeFarms = STAKING[chainId ?? ChainId.AURORA].filter(
+    ({ ID }) => showLegacyFarms || !LEGACY_POOLS.includes(ID)
+  )
   // TODO: Add code back when implementing solution for incorrect farms data.
   // Ignore all stable farms
 

--- a/src/state/user/actions.ts
+++ b/src/state/user/actions.ts
@@ -28,3 +28,4 @@ export const removeSerializedPair = createAction<{ chainId: number; tokenAAddres
 )
 export const toggleURLWarning = createAction<void>('app/toggleURLWarning')
 export const toggleFilterActiveFarms = createAction<void>('user/toggleFilterActiveFarms')
+export const toggleShowLegacyFarms = createAction<void>('user/toggleShowLegacyFarms')

--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -14,7 +14,8 @@ import {
   updateUserExpertMode,
   updateUserSlippageTolerance,
   toggleURLWarning,
-  toggleFilterActiveFarms
+  toggleFilterActiveFarms,
+  toggleShowLegacyFarms
 } from './actions'
 
 import { AppDispatch, AppState } from '../index'
@@ -232,4 +233,13 @@ export function useIsFilterActiveFarms(): boolean {
 export function useToggleFilterActiveFarms(): () => void {
   const dispatch = useDispatch()
   return useCallback(() => dispatch(toggleFilterActiveFarms()), [dispatch])
+}
+
+export function useShowLegacyFarms(): boolean {
+  return useSelector((state: AppState) => state.user.showLegacyFarms)
+}
+
+export function useToggleShowLegacyFarms(): () => void {
+  const dispatch = useDispatch()
+  return useCallback(() => dispatch(toggleShowLegacyFarms()), [dispatch])
 }

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -14,7 +14,8 @@ import {
   updateUserSlippageTolerance,
   updateUserDeadline,
   toggleURLWarning,
-  toggleFilterActiveFarms
+  toggleFilterActiveFarms,
+  toggleShowLegacyFarms
 } from './actions'
 
 const currentTimestamp = () => new Date().getTime()
@@ -50,6 +51,7 @@ export interface UserState {
   timestamp: number
   URLWarningVisible: boolean
   filterActiveFarms: boolean
+  showLegacyFarms: boolean
 }
 
 function pairKey(token0Address: string, token1Address: string) {
@@ -66,7 +68,8 @@ export const initialState: UserState = {
   pairs: {},
   timestamp: currentTimestamp(),
   URLWarningVisible: true,
-  filterActiveFarms: false
+  filterActiveFarms: false,
+  showLegacyFarms: false
 }
 
 export default createReducer(initialState, builder =>
@@ -140,6 +143,10 @@ export default createReducer(initialState, builder =>
     })
     .addCase(toggleFilterActiveFarms, state => {
       state.filterActiveFarms = !state.filterActiveFarms
+      state.timestamp = currentTimestamp()
+    })
+    .addCase(toggleShowLegacyFarms, state => {
+      state.showLegacyFarms = !state.showLegacyFarms
       state.timestamp = currentTimestamp()
     })
 )


### PR DESCRIPTION
- Added `showLegacyFarms` to redux
- Excluded RPC calls updating legacy farms when they're hidden
- Added toggle to farms page to hide legacy farms

https://user-images.githubusercontent.com/94581898/172976863-f8fcc557-afd4-40b1-8ea4-a1bc04e39c9b.mov

