### PR TITLE
Fix ContractAddress icon on mobile

### DIFF
--- a/src/components/ContractAddress/ContractAddress.styles.tsx
+++ b/src/components/ContractAddress/ContractAddress.styles.tsx
@@ -25,6 +25,9 @@ export const StyledContractButton = styled.button`
     background-color: ${({ theme }) => darken(0.1, theme.bg6)};
   }
 
+  display:flex;
+  justify-content:center;
+  align-items:center;
   svg {
     margin-top: 2px;
   }

--- a/src/components/ContractAddress/index.tsx
+++ b/src/components/ContractAddress/index.tsx
@@ -40,7 +40,6 @@ const ContractAddress = ({ token, address, ...rest }: { token?: Token; address?:
         onBlur={handleMouseLeave}
         onMouseLeave={handleMouseLeave}
         onClick={handleClick}
-        style={{ marginLeft: '10px' }}
       >
         <StyledTooltip text={isCopied ? 'Copied!' : 'Copy address to clipboard'} placement="top" show={showTooltip}>
           {isCopied ? <Check size={14} /> : <Copy size={14} />}


### PR DESCRIPTION
Fix ContractAddress copy icon not centered on mobile.

<img width="396" alt="Screen Shot 2022-06-18 at 13 21 47" src="https://user-images.githubusercontent.com/96993065/174447613-005bba50-073d-440c-940e-0fce99e3d632.png">

