### PR TITLE
adding AddToMetamaskButton in pools pages.

### DIFF
--- a/src/components/AddToMetamask/index.tsx
+++ b/src/components/AddToMetamask/index.tsx
@@ -13,10 +13,15 @@ import MetamaskIcon from '../../assets/images/metamask.png'
 
 const StyledMetamaskButton = styled(StyledMenuButton)`
   width: 35px;
-  margin-right: 10px;
+`
+const StyledMetamaskImg = styled.img`
+  width: 20px;
+  :hover {
+    cursor: pointer;
+  }
 `
 
-function AddToMetamaskButton({ token }: { token: Token }) {
+function AddToMetamaskButton({ token, noBackground, ...otherProps }: { token: Token; noBackground?: boolean }) {
   const { library } = useActiveWeb3React()
 
   if (!token) {
@@ -24,11 +29,21 @@ function AddToMetamaskButton({ token }: { token: Token }) {
   }
 
   const { symbol, address, decimals } = token
+
   return library?.provider?.isMetaMask ? (
     <MouseoverTooltip text={`Add ${symbol} to Metamask`}>
-      <StyledMetamaskButton onClick={() => registerToken(address, symbol!, decimals)}>
-        <img src={MetamaskIcon} alt={'Metamask logo'} style={{ width: '100%' }} />
-      </StyledMetamaskButton>
+      {noBackground ? (
+        <StyledMetamaskImg
+          src={MetamaskIcon}
+          alt={'Metamask logo'}
+          onClick={() => registerToken(address, symbol!, decimals)}
+          {...otherProps}
+        />
+      ) : (
+        <StyledMetamaskButton onClick={() => registerToken(address, symbol!, decimals)} {...otherProps}>
+          <img src={MetamaskIcon} alt={'Metamask logo'} style={{ width: '100%' }} />
+        </StyledMetamaskButton>
+      )}
     </MouseoverTooltip>
   ) : null
 }

--- a/src/components/PositionCard/PositionCard.styles.tsx
+++ b/src/components/PositionCard/PositionCard.styles.tsx
@@ -1,9 +1,10 @@
 import styled from 'styled-components'
 import { darken } from 'polished'
 
-import { RowBetween } from "../Row"
+import { RowBetween } from '../Row'
 import Card, { LightCard } from '../Card'
 import { ButtonEmpty } from '../Button'
+import AddToMetamaskButton from '../AddToMetamask'
 
 export const ManageButton = styled(ButtonEmpty)`
   color: ${({ theme }) => theme.white};
@@ -24,4 +25,8 @@ export const StyledPositionCard = styled(LightCard)<{ bgColor: any }>`
   border: none;
   position: relative;
   overflow: hidden;
+`
+
+export const StyledAddToMetamaskButton = styled(AddToMetamaskButton)`
+  margin-left: 5px;
 `

--- a/src/components/PositionCard/StablePositionCard/index.tsx
+++ b/src/components/PositionCard/StablePositionCard/index.tsx
@@ -21,6 +21,7 @@ import { BIG_INT_ZERO } from '../../../constants'
 import { useHistory } from 'react-router-dom'
 import CurrencyLogo from '../../CurrencyLogo'
 import MultipleCurrencyLogo from '../../MultipleCurrencyLogo'
+import AddToMetamaskButton from '../../AddToMetamask'
 
 import ContractAddress from '../../ContractAddress'
 import { TYPE } from '../../../theme'
@@ -96,6 +97,9 @@ const StyledContractAddress = styled(ContractAddress)`
 font-size: 12px !important;
 `};
 `
+
+const StyledAddToMetamaskButton = styled(AddToMetamaskButton)`
+  margin-right: 5px;`
 
 interface PositionCardProps {
   pair: Pair
@@ -216,6 +220,7 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
               {stablePoolData.tokens.map(({ token, percent, value }) => (
                 <FixedHeightRow key={token.name}>
                   <div>
+                    <StyledAddToMetamaskButton token={token} noBackground />
                     <CurrencyLogo size="20px" style={{ marginRight: '8px' }} currency={unwrappedToken(token)} />
                     {token.name}
                   </div>

--- a/src/components/PositionCard/index.tsx
+++ b/src/components/PositionCard/index.tsx
@@ -26,7 +26,7 @@ import { PositionCardProps } from './PositionCard.types'
 
 import { TokenPairBackgroundColor } from '../earn/PoolCardTri.styles'
 
-import { ManageButton, FixedHeightRow, StyledPositionCard } from './PositionCard.styles'
+import { ManageButton, FixedHeightRow, StyledPositionCard, StyledAddToMetamaskButton } from './PositionCard.styles'
 
 export default function FullPositionCard({ pair, border }: PositionCardProps) {
   const { account } = useActiveWeb3React()
@@ -131,6 +131,7 @@ export default function FullPositionCard({ pair, border }: PositionCardProps) {
                     {token0Deposited?.toSignificant(6)}
                   </Text>
                   <CurrencyLogo size="20px" style={{ marginLeft: '8px' }} currency={currency0} />
+                  <StyledAddToMetamaskButton token={token0} noBackground />
                 </RowFixed>
               ) : (
                 '-'
@@ -149,6 +150,7 @@ export default function FullPositionCard({ pair, border }: PositionCardProps) {
                     {token1Deposited?.toSignificant(6)}
                   </Text>
                   <CurrencyLogo size="20px" style={{ marginLeft: '8px' }} currency={currency1} />
+                  <StyledAddToMetamaskButton token={token1} noBackground />
                 </RowFixed>
               ) : (
                 '-'

--- a/src/pages/Swap/Swap.styles.tsx
+++ b/src/pages/Swap/Swap.styles.tsx
@@ -1,5 +1,7 @@
 import styled from 'styled-components'
 
+import AddToMetamaskButton from '../../components/AddToMetamask'
+
 export const WarningWrapper = styled.div`
   max-width: 420px;
   width: 100%;
@@ -47,4 +49,8 @@ export const HeadingContainer = styled.div`
 
 export const HeaderButtonsContainer = styled.div`
   display: flex;
+`
+
+export const StyledAddToMetamaskButton = styled(AddToMetamaskButton)`
+  margin-right: 10px;
 `

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -63,12 +63,12 @@ import {
   SwapContainer,
   IconContainer,
   HeadingContainer,
-  HeaderButtonsContainer
+  HeaderButtonsContainer,
+  StyledAddToMetamaskButton
 } from './Swap.styles'
 import { isStableSwapHighPriceImpact, useDerivedStableSwapInfo } from '../../state/stableswap/hooks'
 import { useStableSwapCallback } from '../../hooks/useStableSwapCallback'
 
-import AddToMetamaskButton from '../../components/AddToMetamask'
 export default function Swap() {
   const loadedUrlParams = useDefaultsFromURLSearch()
   const { t } = useTranslation()
@@ -438,7 +438,7 @@ export default function Swap() {
                 <HeadingContainer>
                   <TYPE.largeHeader>Swap</TYPE.largeHeader>
                   <HeaderButtonsContainer>
-                    {currencies.OUTPUT && <AddToMetamaskButton token={currencies.OUTPUT as Token} />}
+                    {currencies.OUTPUT && <StyledAddToMetamaskButton token={currencies.OUTPUT as Token} />}
                     <Settings />
                   </HeaderButtonsContainer>
                 </HeadingContainer>


### PR DESCRIPTION

- Add AddToMetaMaskButton to StablePools and Pools pages.
- Add noBackground prop for using metamask image only as button.


<img width="754" alt="Screen Shot 2022-06-27 at 17 28 31" src="https://user-images.githubusercontent.com/96993065/176032444-93310b82-9520-4779-8fd4-3672eba56e57.png">

<img width="744" alt="Screen Shot 2022-06-27 at 17 40 42" src="https://user-images.githubusercontent.com/96993065/176032461-85b0e400-024d-4d52-aa71-5cf09330accf.png">

