### PR TITLE
Add to metamask button changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "interface",
   "description": "Trisolaris Interface",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "homepage": ".",
   "private": true,
   "devDependencies": {

--- a/src/components/AddToMetamask/index.tsx
+++ b/src/components/AddToMetamask/index.tsx
@@ -15,6 +15,7 @@ const StyledMetamaskButton = styled(StyledMenuButton)`
   width: 35px;
 `
 const StyledMetamaskImg = styled.img`
+ display:flex;
   width: 20px;
   :hover {
     cursor: pointer;

--- a/src/components/PositionCard/PositionCard.styles.tsx
+++ b/src/components/PositionCard/PositionCard.styles.tsx
@@ -29,4 +29,5 @@ export const StyledPositionCard = styled(LightCard)<{ bgColor: any }>`
 
 export const StyledAddToMetamaskButton = styled(AddToMetamaskButton)`
   margin-left: 5px;
+  width: 15px;
 `

--- a/src/components/PositionCard/StablePositionCard/index.tsx
+++ b/src/components/PositionCard/StablePositionCard/index.tsx
@@ -99,7 +99,14 @@ font-size: 12px !important;
 `
 
 const StyledAddToMetamaskButton = styled(AddToMetamaskButton)`
-  margin-right: 5px;`
+  margin: 0 5px;
+  width: 15px;
+`
+
+const CurrencyContainer = styled.div`
+  display: flex;
+  align-items: center;
+`
 
 interface PositionCardProps {
   pair: Pair
@@ -219,11 +226,11 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
               </TYPE.subHeader>
               {stablePoolData.tokens.map(({ token, percent, value }) => (
                 <FixedHeightRow key={token.name}>
-                  <div>
+                  <CurrencyContainer>
+                    <CurrencyLogo size="20px" currency={unwrappedToken(token)} />
                     <StyledAddToMetamaskButton token={token} noBackground />
-                    <CurrencyLogo size="20px" style={{ marginRight: '8px' }} currency={unwrappedToken(token)} />
                     {token.name}
-                  </div>
+                  </CurrencyContainer>
                   <StyledText fontWeight={500} marginLeft={'6px'}>
                     {`${value.toSignificant(4)} (${percent.toFixed(2)}%)`}
                   </StyledText>

--- a/src/components/SearchModal/CurrencyList.tsx
+++ b/src/components/SearchModal/CurrencyList.tsx
@@ -17,6 +17,7 @@ import { FadedSpan, MenuItem } from './styleds'
 import Loader from '../Loader'
 import { isTokenOnList } from '../../utils'
 import { useTranslation } from 'react-i18next'
+import AddToMetamaskButton from '../AddToMetamask'
 
 function currencyKey(currency: Currency): string {
   return currency instanceof Token ? currency.address : currency === CETH ? 'ETH' : ''
@@ -57,14 +58,24 @@ const StyledRemoveTokenButton = styled(LinkStyledButton)`
   font-size: 12px;
 `
 
-function Balance({ balance }: { balance: CurrencyAmount }) {
-  return <StyledBalanceText title={balance.toExact()}>{balance.toSignificant(4)}</StyledBalanceText>
-}
-
 const TagContainer = styled.div`
   display: flex;
   justify-content: flex-end;
 `
+
+const LogoAndButtonContainer = styled.div`
+  display: flex;
+  align-items: center;
+`
+
+const StyledAddToMetamaskButton = styled(AddToMetamaskButton)`
+  width: 15px;
+  margin-left: 5px;
+`
+
+function Balance({ balance }: { balance: CurrencyAmount }) {
+  return <StyledBalanceText title={balance.toExact()}>{balance.toSignificant(4)}</StyledBalanceText>
+}
 
 function TokenTags({ currency }: { currency: Currency }) {
   if (!(currency instanceof WrappedTokenInfo)) {
@@ -128,7 +139,10 @@ function CurrencyRow({
       disabled={isSelected}
       selected={otherSelected}
     >
-      <CurrencyLogo currency={currency} size={'24px'} />
+      <LogoAndButtonContainer>
+        <CurrencyLogo currency={currency} size={'24px'} />
+        <StyledAddToMetamaskButton noBackground token={currency as Token} />
+      </LogoAndButtonContainer>
       <Column>
         <Text title={currency.name} fontWeight={500}>
           {currency.symbol}

--- a/src/pages/Swap/Swap.styles.tsx
+++ b/src/pages/Swap/Swap.styles.tsx
@@ -46,11 +46,3 @@ export const HeadingContainer = styled.div`
   align-items: center;
   justify-content: space-between;
 `
-
-export const HeaderButtonsContainer = styled.div`
-  display: flex;
-`
-
-export const StyledAddToMetamaskButton = styled(AddToMetamaskButton)`
-  margin-right: 10px;
-`

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -63,8 +63,6 @@ import {
   SwapContainer,
   IconContainer,
   HeadingContainer,
-  HeaderButtonsContainer,
-  StyledAddToMetamaskButton
 } from './Swap.styles'
 import { isStableSwapHighPriceImpact, useDerivedStableSwapInfo } from '../../state/stableswap/hooks'
 import { useStableSwapCallback } from '../../hooks/useStableSwapCallback'
@@ -437,10 +435,7 @@ export default function Swap() {
               <AutoColumn gap={'md'}>
                 <HeadingContainer>
                   <TYPE.largeHeader>Swap</TYPE.largeHeader>
-                  <HeaderButtonsContainer>
-                    {currencies.OUTPUT && <StyledAddToMetamaskButton token={currencies.OUTPUT as Token} />}
-                    <Settings />
-                  </HeaderButtonsContainer>
+                  <Settings />
                 </HeadingContainer>
 
                 <CurrencyInputPanel


### PR DESCRIPTION
- Removing Button from Swap header, moved into CurrencyList selection.
- Fix vertical alignement in Poolspages, and put button to the right of token logo.

<img width="412" alt="Screen Shot 2022-07-01 at 15 52 04" src="https://user-images.githubusercontent.com/96993065/176954531-423e356e-5440-4f1b-bb00-bf9e8ade12db.png">


<img width="742" alt="Screen Shot 2022-07-01 at 12 48 43" src="https://user-images.githubusercontent.com/96993065/176954512-2b20e88f-398b-4e7e-907e-cc786780d75f.png">
