### PR TITLE
Notification popup for AddToMetaMask user rejections.

### DIFF
--- a/src/components/AddToMetamask/index.tsx
+++ b/src/components/AddToMetamask/index.tsx
@@ -6,16 +6,18 @@ import { StyledMenuButton } from '../../components/StyledMenu'
 import { MouseoverTooltip } from '../Tooltip'
 
 import { useActiveWeb3React } from '../../hooks'
+import { useAddPopup } from '../../state/application/hooks'
 
 import { registerToken } from '../../utils/wallet'
 
 import MetamaskIcon from '../../assets/images/metamask.png'
+import { ICON_TYPES } from '../Popups/CustomPopup'
 
 const StyledMetamaskButton = styled(StyledMenuButton)`
   width: 35px;
 `
 const StyledMetamaskImg = styled.img`
- display:flex;
+  display: flex;
   width: 20px;
   :hover {
     cursor: pointer;
@@ -24,6 +26,7 @@ const StyledMetamaskImg = styled.img`
 
 function AddToMetamaskButton({ token, noBackground, ...otherProps }: { token: Token; noBackground?: boolean }) {
   const { library } = useActiveWeb3React()
+  const addPopup = useAddPopup()
 
   if (!token) {
     return null
@@ -31,15 +34,23 @@ function AddToMetamaskButton({ token, noBackground, ...otherProps }: { token: To
 
   const { symbol, address, decimals } = token
 
+  async function addToken() {
+    try {
+      await registerToken(address, symbol!, decimals)
+    } catch (e) {
+      addPopup({
+        customContent: {
+          text: 'User Rejected adding the token to MetaMask.',
+          icon: ICON_TYPES.ALERT
+        }
+      })
+    }
+  }
+
   return library?.provider?.isMetaMask ? (
     <MouseoverTooltip text={`Add ${symbol} to Metamask`}>
       {noBackground ? (
-        <StyledMetamaskImg
-          src={MetamaskIcon}
-          alt={'Metamask logo'}
-          onClick={() => registerToken(address, symbol!, decimals)}
-          {...otherProps}
-        />
+        <StyledMetamaskImg src={MetamaskIcon} alt={'Metamask logo'} onClick={addToken} {...otherProps} />
       ) : (
         <StyledMetamaskButton onClick={() => registerToken(address, symbol!, decimals)} {...otherProps}>
           <img src={MetamaskIcon} alt={'Metamask logo'} style={{ width: '100%' }} />

--- a/src/components/Popups/CustomPopup.tsx
+++ b/src/components/Popups/CustomPopup.tsx
@@ -1,0 +1,25 @@
+import React, { useContext } from 'react'
+import styled, { ThemeContext } from 'styled-components'
+import { AlertCircle, CheckCircle } from 'lucide-react'
+
+import { AutoColumn } from '../Column'
+import { AutoRow } from '../Row'
+
+const RowNoFlex = styled(AutoRow)`
+  flex-wrap: nowrap;
+  align-items: center;
+`
+
+export enum ICON_TYPES {
+  ALERT = 'alert',
+  SUCCESS = 'success'
+}
+
+export default function CustomPopup({ text, icon }: { text: string; icon?: ICON_TYPES }) {
+  return (
+    <RowNoFlex>
+      {icon && <div style={{ paddingRight: 16 }}>{icon === ICON_TYPES.ALERT ? <AlertCircle /> : <CheckCircle />}</div>}
+      <AutoColumn gap="8px">{text}</AutoColumn>
+    </RowNoFlex>
+  )
+}

--- a/src/components/Popups/PopupItem.tsx
+++ b/src/components/Popups/PopupItem.tsx
@@ -7,6 +7,7 @@ import { PopupContent } from '../../state/application/actions'
 import { useRemovePopup } from '../../state/application/hooks'
 import ListUpdatePopup from './ListUpdatePopup'
 import TransactionPopup from './TransactionPopup'
+import CustomPopup from './CustomPopup'
 
 export const StyledClose = styled(X)`
   position: absolute;
@@ -82,6 +83,11 @@ export default function PopupItem({
       listUpdate: { listUrl, oldList, newList, auto }
     } = content
     popupContent = <ListUpdatePopup popKey={popKey} listUrl={listUrl} oldList={oldList} newList={newList} auto={auto} />
+  } else if ('customContent' in content) {
+    const {
+      customContent: { text, icon }
+    } = content
+    popupContent = <CustomPopup text={text} icon={icon} />
   }
 
   const faderStyle = useSpring({

--- a/src/state/application/actions.ts
+++ b/src/state/application/actions.ts
@@ -1,5 +1,6 @@
 import { createAction } from '@reduxjs/toolkit'
 import { TokenList } from '@pangolindex/token-lists'
+import { ICON_TYPES } from '../../components/Popups/CustomPopup'
 
 export type PopupContent =
   | {
@@ -15,6 +16,12 @@ export type PopupContent =
         oldList: TokenList
         newList: TokenList
         auto: boolean
+      }
+    }
+  | {
+      customContent: {
+        text: string,
+        icon: ICON_TYPES
       }
     }
 

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -39,6 +39,7 @@ export const registerToken = async (
       return wasAdded
     }
   } catch (error) {
-    console.log(error)
+    console.error(error)
+    throw new Error(`${(error as any).message}`)
   }
 }


### PR DESCRIPTION
DRAFT: Needs to be updated with new AddToMetamask implementation to be done.

- Add CustomPopup component for success/alert notifications other than transactions / list updates.
- Add CustomPopup in AddToMetaMask for notifiying about user rejecting adding the token.