### PR TITLE
Remove previously merged AddToMetaMask changes on Swap Page.

### DIFF
--- a/src/components/SearchModal/CurrencyList.tsx
+++ b/src/components/SearchModal/CurrencyList.tsx
@@ -17,7 +17,6 @@ import { FadedSpan, MenuItem } from './styleds'
 import Loader from '../Loader'
 import { isTokenOnList } from '../../utils'
 import { useTranslation } from 'react-i18next'
-import AddToMetamaskButton from '../AddToMetamask'
 
 function currencyKey(currency: Currency): string {
   return currency instanceof Token ? currency.address : currency === CETH ? 'ETH' : ''
@@ -61,16 +60,6 @@ const StyledRemoveTokenButton = styled(LinkStyledButton)`
 const TagContainer = styled.div`
   display: flex;
   justify-content: flex-end;
-`
-
-const LogoAndButtonContainer = styled.div`
-  display: flex;
-  align-items: center;
-`
-
-const StyledAddToMetamaskButton = styled(AddToMetamaskButton)`
-  width: 15px;
-  margin-left: 5px;
 `
 
 function Balance({ balance }: { balance: CurrencyAmount }) {
@@ -139,10 +128,7 @@ function CurrencyRow({
       disabled={isSelected}
       selected={otherSelected}
     >
-      <LogoAndButtonContainer>
-        <CurrencyLogo currency={currency} size={'24px'} />
-        <StyledAddToMetamaskButton noBackground token={currency as Token} />
-      </LogoAndButtonContainer>
+      <CurrencyLogo currency={currency} size={'24px'} />
       <Column>
         <Text title={currency.name} fontWeight={500}>
           {currency.symbol}

--- a/src/pages/Swap/Swap.styles.tsx
+++ b/src/pages/Swap/Swap.styles.tsx
@@ -46,3 +46,11 @@ export const HeadingContainer = styled.div`
   align-items: center;
   justify-content: space-between;
 `
+
+export const HeaderButtonsContainer = styled.div`
+  display: flex;
+`
+
+export const StyledAddToMetamaskButton = styled(AddToMetamaskButton)`
+  margin-right: 10px;
+`

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -63,6 +63,8 @@ import {
   SwapContainer,
   IconContainer,
   HeadingContainer,
+  HeaderButtonsContainer,
+  StyledAddToMetamaskButton
 } from './Swap.styles'
 import { isStableSwapHighPriceImpact, useDerivedStableSwapInfo } from '../../state/stableswap/hooks'
 import { useStableSwapCallback } from '../../hooks/useStableSwapCallback'
@@ -435,7 +437,10 @@ export default function Swap() {
               <AutoColumn gap={'md'}>
                 <HeadingContainer>
                   <TYPE.largeHeader>Swap</TYPE.largeHeader>
-                  <Settings />
+                  <HeaderButtonsContainer>
+                    {currencies.OUTPUT && <StyledAddToMetamaskButton token={currencies.OUTPUT as Token} />}
+                    <Settings />
+                  </HeaderButtonsContainer>
                 </HeadingContainer>
 
                 <CurrencyInputPanel


### PR DESCRIPTION
- Rolling back previously merged AddToMetaMask changes of swap page.

Before:
<img width="402" alt="Screen Shot 2022-07-12 at 17 55 57" src="https://user-images.githubusercontent.com/96993065/178593717-e14b5d58-1bff-409a-bbf2-8d97fac64cee.png">

After: (Same as prod) 
<img width="506" alt="Screen Shot 2022-07-12 at 17 56 04" src="https://user-images.githubusercontent.com/96993065/178593743-31e087cb-1915-4b54-962b-47f76e4d536f.png">
