### PR TITLE
Fix stablepool farm cards routing.

### DIFF
--- a/src/components/earn/PoolCardTri/index.tsx
+++ b/src/components/earn/PoolCardTri/index.tsx
@@ -43,7 +43,7 @@ export type PoolCardTriProps = {
   totalStakedInUSD: number
   isStaking: boolean
   version: number
-  stableSwapPoolName?: StableSwapPoolName | null
+  stableSwapPoolName: StableSwapPoolName | null
   nonTriAPRs: NonTriAPR[]
   friendlyFarmName: string | null
   isFeatured?: boolean

--- a/src/components/earn/PoolCardTri/index.tsx
+++ b/src/components/earn/PoolCardTri/index.tsx
@@ -43,7 +43,7 @@ export type PoolCardTriProps = {
   totalStakedInUSD: number
   isStaking: boolean
   version: number
-  stableSwapPoolName?: StableSwapPoolName
+  stableSwapPoolName?: StableSwapPoolName | null
   nonTriAPRs: NonTriAPR[]
   friendlyFarmName: string | null
   isFeatured?: boolean
@@ -154,6 +154,7 @@ const DefaultPoolCardtri = ({
 type StablePoolCardTriProps = PoolCardTriProps & { stableSwapPoolName: StableSwapPoolName }
 
 const StableStakingPoolCardTRI = (props: StablePoolCardTriProps) => {
+
   const { version } = props
 
   const stakingInfo = useSingleStableFarm(Number(version), props.stableSwapPoolName)

--- a/src/pages/EarnTri/EarnTri.tsx
+++ b/src/pages/EarnTri/EarnTri.tsx
@@ -100,6 +100,7 @@ export default function EarnTri() {
                   isStaking={isTokenAmountPositive(farm.stakedAmount)}
                   friendlyFarmName={farm.friendlyFarmName}
                   isFeatured={farm.isFeatured}
+                  stableSwapPoolName={farm.stableSwapPoolName}
                 />
               ))}
             </PoolSection>
@@ -158,6 +159,7 @@ export default function EarnTri() {
                   noTriRewards={farm.noTriRewards}
                   isStaking={isTokenAmountPositive(farm.stakedAmount)}
                   friendlyFarmName={farm.friendlyFarmName}
+                  stableSwapPoolName={farm.stableSwapPoolName}
                 />
               ))}
             </PoolSection>
@@ -193,6 +195,7 @@ export default function EarnTri() {
                   noTriRewards={farm.noTriRewards}
                   isStaking={isTokenAmountPositive(farm.stakedAmount)}
                   friendlyFarmName={farm.friendlyFarmName}
+                  stableSwapPoolName={farm.stableSwapPoolName}
                 />
               ))}
             </PoolSection>

--- a/src/pages/EarnTri/EarnTri.tsx
+++ b/src/pages/EarnTri/EarnTri.tsx
@@ -130,6 +130,7 @@ export default function EarnTri() {
               isStaking={isTokenAmountPositive(farm.stakedAmount)}
               friendlyFarmName={farm.friendlyFarmName}
               isFeatured={farm.isFeatured}
+              stableSwapPoolName={farm.stableSwapPoolName}
             />
           ))}
         </PoolSection>


### PR DESCRIPTION
- Fix stablepool farm cards routing incorrectly when filtering by staked farms ("Show only my pools" switch).

### Before:
<img width="888" alt="Screen Shot 2022-07-14 at 15 54 46" src="https://user-images.githubusercontent.com/96993065/179072087-41a4eb02-1cc5-4146-ad4c-40ec37abdd63.png">

### After:
<img width="824" alt="Screen Shot 2022-07-14 at 15 55 05" src="https://user-images.githubusercontent.com/96993065/179072112-05f95300-e151-4e67-9233-036721da45d9.png">
