### PR TITLE
Add USP and BINARIS as common base tokens

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -20,7 +20,8 @@ import {
   WBTC,
   ORBITAL,
   SMARTPAD,
-  USP
+  USP,
+  BINARIS
 } from './tokens'
 
 export const GAS_PRICE = 250
@@ -65,7 +66,9 @@ const COMMON_BASES: ChainTokenList = {
     STNEAR[ChainId.AURORA],
     PLY[ChainId.AURORA],
     AURORA[ChainId.AURORA],
-    WBTC[ChainId.AURORA]
+    WBTC[ChainId.AURORA],
+    USP[ChainId.AURORA],
+    BINARIS[ChainId.AURORA]
   ]
 }
 


### PR DESCRIPTION
- Adding USP and BINARIS to COMMON_BASE_TOKENS.

<img width="446" alt="Screen Shot 2022-07-24 at 21 03 36" src="https://user-images.githubusercontent.com/96993065/180671472-8650cf52-aebf-4708-a380-996e47ab037b.png">
