### PR TITLE
Replace 3pool rewarder by new one

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "interface",
   "description": "Trisolaris Interface",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "homepage": ".",
   "private": true,
   "devDependencies": {

--- a/src/state/stake/stake-constants.ts
+++ b/src/state/stake/stake-constants.ts
@@ -495,7 +495,7 @@ const AURORA_POOLS: StakingTri[] = [
     poolId: 28,
     tokens: STABLESWAP_POOLS[StableSwapPoolName.USDC_USDT_USN].poolTokens,
     lpAddress: STABLESWAP_POOLS[StableSwapPoolName.USDC_USDT_USN].lpToken.address,
-    rewarderAddress: '0x78391f26397A099Ec9cC346A23f856d1284cBd06',
+    rewarderAddress: '0x34998bb1b4721f0418B22aae5a252C3167F1e7bF',
     allocPoint: 1,
     inStaging: false,
     stableSwapPoolName: StableSwapPoolName.USDC_USDT_USN,


### PR DESCRIPTION
- Replacing USDT-USDC-USN rewarder address by new one with USN as reward token.

### Note:
 Don't merge until reward change is ready to go live