### PR TITLE
B/fix deposits amounts in usd

### DIFF
--- a/src/components/PositionCard/StablePositionCard/index.tsx
+++ b/src/components/PositionCard/StablePositionCard/index.tsx
@@ -144,7 +144,7 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
     push(`${pathname}/remove/${name}`)
   }
 
-  const poolTVL = stablePoolData.totalLocked?.toFixed(0)
+  const poolTVL = stablePoolData.totalLockedInUsd?.toFixed(0)
   const formattedPoolData = [
     {
       label: 'Virtual Price',

--- a/src/components/PositionCard/StablePositionCard/index.tsx
+++ b/src/components/PositionCard/StablePositionCard/index.tsx
@@ -1,4 +1,4 @@
-import { Pair } from '@trisolaris/sdk'
+import { JSBI, Pair } from '@trisolaris/sdk'
 import { darken } from 'polished'
 import React, { useState, useContext } from 'react'
 import { Text } from 'rebass'
@@ -144,7 +144,9 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
     push(`${pathname}/remove/${name}`)
   }
 
-  const poolTVL = stablePoolData.totalLockedInUsd?.toFixed(0)
+  const reserve = stablePoolData.reserve
+  const poolTVL = reserve?.greaterThan(JSBI.BigInt(1000)) ? reserve?.toFixed(0) : reserve?.toFixed(2) // Avoid rounding down on small tvl numbers
+
   const formattedPoolData = [
     {
       label: 'Virtual Price',

--- a/src/constants/abis/stableswap/auErc20.json
+++ b/src/constants/abis/stableswap/auErc20.json
@@ -1,0 +1,590 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "underlying_", "type": "address" },
+      { "internalType": "contract ComptrollerInterface", "name": "comptroller_", "type": "address" },
+      { "internalType": "contract InterestRateModel", "name": "interestRateModel_", "type": "address" },
+      { "internalType": "uint256", "name": "initialExchangeRateMantissa_", "type": "uint256" },
+      { "internalType": "string", "name": "name_", "type": "string" },
+      { "internalType": "string", "name": "symbol_", "type": "string" },
+      { "internalType": "uint8", "name": "decimals_", "type": "uint8" },
+      { "internalType": "address payable", "name": "admin_", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  { "inputs": [], "name": "BadInput", "type": "error" },
+  { "inputs": [], "name": "InvalidAccountPair", "type": "error" },
+  { "inputs": [], "name": "InvalidCloseAmountRequested", "type": "error" },
+  { "inputs": [], "name": "MarketNotFresh", "type": "error" },
+  { "inputs": [], "name": "TokenInsufficientCash", "type": "error" },
+  { "inputs": [], "name": "Unauthorized", "type": "error" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "cashPrior", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "interestAccumulated", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "borrowIndex", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalBorrows", "type": "uint256" }
+    ],
+    "name": "AccrueInterest",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "spender", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "borrowAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "accountBorrows", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalBorrows", "type": "uint256" }
+    ],
+    "name": "Borrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "liquidator", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "address", "name": "auTokenCollateral", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "LiquidateBorrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "minter", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "mintAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "mintTokens", "type": "uint256" }
+    ],
+    "name": "Mint",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldAdmin", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newAdmin", "type": "address" }
+    ],
+    "name": "NewAdmin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract ComptrollerInterface",
+        "name": "oldComptroller",
+        "type": "address"
+      },
+      { "indexed": false, "internalType": "contract ComptrollerInterface", "name": "newComptroller", "type": "address" }
+    ],
+    "name": "NewComptroller",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract InterestRateModel",
+        "name": "oldInterestRateModel",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract InterestRateModel",
+        "name": "newInterestRateModel",
+        "type": "address"
+      }
+    ],
+    "name": "NewMarketInterestRateModel",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldPendingAdmin", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newPendingAdmin", "type": "address" }
+    ],
+    "name": "NewPendingAdmin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldProtocolSeizeShareMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newProtocolSeizeShareMantissa", "type": "uint256" }
+    ],
+    "name": "NewProtocolSeizeShare",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldReserveFactorMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newReserveFactorMantissa", "type": "uint256" }
+    ],
+    "name": "NewReserveFactor",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "redeemer", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "redeemAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }
+    ],
+    "name": "Redeem",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "payer", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "accountBorrows", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalBorrows", "type": "uint256" }
+    ],
+    "name": "RepayBorrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "benefactor", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "addAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newTotalReserves", "type": "uint256" }
+    ],
+    "name": "ReservesAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "admin", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "reduceAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newTotalReserves", "type": "uint256" }
+    ],
+    "name": "ReservesReduced",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  { "inputs": [], "name": "_acceptAdmin", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "addAmount", "type": "uint256" }],
+    "name": "_addReserves",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "reduceAmount", "type": "uint256" }],
+    "name": "_reduceReserves",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "contract ComptrollerInterface", "name": "newComptroller", "type": "address" }],
+    "name": "_setComptroller",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "contract InterestRateModel", "name": "newInterestRateModel", "type": "address" }],
+    "name": "_setInterestRateModel",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address payable", "name": "newPendingAdmin", "type": "address" }],
+    "name": "_setPendingAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "newProtocolSeizeShareMantissa", "type": "uint256" }],
+    "name": "_setProtocolSeizeShare",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "newReserveFactorMantissa", "type": "uint256" }],
+    "name": "_setReserveFactor",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "accrualBlockTimestamp",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "inputs": [], "name": "accrueInterest", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [],
+    "name": "admin",
+    "outputs": [{ "internalType": "address payable", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "address", "name": "spender", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }],
+    "name": "balanceOfUnderlying",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "borrowAmount", "type": "uint256" }],
+    "name": "borrow",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "borrowBalanceCurrent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "borrowBalanceStored",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "borrowIndex",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "borrowRatePerTimestamp",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "comptroller",
+    "outputs": [{ "internalType": "contract ComptrollerInterface", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "exchangeRateCurrent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "exchangeRateStored",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "getAccountSnapshot",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "getBorrowDataOfAccount",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCash",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "getSupplyDataOfOneAccount",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account1", "type": "address" },
+      { "internalType": "address", "name": "account2", "type": "address" }
+    ],
+    "name": "getSupplyDataOfTwoAccount",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "interestRateModel",
+    "outputs": [{ "internalType": "contract InterestRateModel", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isAuToken",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "internalType": "contract AuTokenInterface", "name": "auTokenCollateral", "type": "address" }
+    ],
+    "name": "liquidateBorrow",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "mintAmount", "type": "uint256" }],
+    "name": "mint",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingAdmin",
+    "outputs": [{ "internalType": "address payable", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "protocolSeizeShareMantissa",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }],
+    "name": "redeem",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "redeemAmount", "type": "uint256" }],
+    "name": "redeemUnderlying",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "repayAmount", "type": "uint256" }],
+    "name": "repayBorrow",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" }
+    ],
+    "name": "repayBorrowBehalf",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reserveFactorMantissa",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "seize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "supplyRatePerTimestamp",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "contract EIP20NonStandardInterface", "name": "token", "type": "address" }],
+    "name": "sweepToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalBorrows",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalBorrowsCurrent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalReserves",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "dst", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "src", "type": "address" },
+      { "internalType": "address", "name": "dst", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "underlying",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -28,6 +28,7 @@ import { GOVERNANCE_ADDRESS } from '../constants'
 import { STAKING } from '../state/stake/stake-constants'
 import { isMetaPool, StableSwapPoolName, STABLESWAP_POOLS } from '../state/stableswap/constants'
 import PTRI_ABI from '../constants/abis/pTri/ptri.json'
+import AUERC20 from '../constants/abis/stableswap/auErc20.json'
 
 // returns null on errors
 function useContract(address: string | undefined, ABI: any, withSignerIfPossible = true): Contract | null {
@@ -183,4 +184,8 @@ export function usePTriContract(withSignerIfPossible = true): Contract | null {
 
     return pTriContract
   }, [library, chainId])
+}
+
+export function useAuTokenContract(tokenAddress?: string, withSignerIfPossible?: boolean): Contract | null {
+  return useContract(tokenAddress, AUERC20, withSignerIfPossible)
 }

--- a/src/hooks/useStablePoolsData.ts
+++ b/src/hooks/useStablePoolsData.ts
@@ -40,6 +40,7 @@ export interface StablePoolDataType {
   lpToken: Token | null
   disableAddLiquidity: boolean
   totalLockedInUsd: TokenAmount | null
+  avgExchangeRate: JSBI | null
 }
 
 export interface UserShareType {
@@ -187,7 +188,11 @@ export default function useStablePoolsData(poolName: StableSwapPoolName): PoolDa
     totalLockedInUsd:
       pool.name === StableSwapPoolName.AUUSDC_AUUSDT
         ? new TokenAmount(USDC[ChainId.AURORA], tokenBalancesUSDSum)
-        : totalLpTokenBalance
+        : totalLpTokenBalance,
+    avgExchangeRate:
+      pool.name === StableSwapPoolName.AUUSDC_AUUSDT
+        ? JSBI.divide(JSBI.ADD(auUSDCExchangeRate, auUSDTExchangeRate), JSBI.BigInt(2))
+        : null
   }
 
   // User Data

--- a/src/pages/StableSwapPoolAddLiquidity/StableSwapPoolAddLiquidityImpl.tsx
+++ b/src/pages/StableSwapPoolAddLiquidity/StableSwapPoolAddLiquidityImpl.tsx
@@ -156,9 +156,11 @@ export default function StableSwapPoolAddLiquidityImpl({ stableSwapPoolName }: P
     .join('')}`
 
   const modalHeader = () => {
-    const { virtualPrice, lpToken } = poolData
+    const { virtualPrice, lpToken, avgExchangeRate } = poolData
     const usdEstimate =
-      virtualPrice && minToMint && lpToken ? getLpTokenUsdEstimate(virtualPrice, minToMint, lpToken) : null
+      virtualPrice && minToMint && lpToken
+        ? getLpTokenUsdEstimate(virtualPrice, minToMint, lpToken, avgExchangeRate)
+        : null
 
     if (!minToMint) {
       return null

--- a/src/pages/StableSwapPoolAddLiquidity/StableSwapPoolAddLiquidityImpl.tsx
+++ b/src/pages/StableSwapPoolAddLiquidity/StableSwapPoolAddLiquidityImpl.tsx
@@ -42,7 +42,7 @@ import { AddRemoveTabs } from '../../components/NavigationTabs'
 import confirmStableSwapAddLiquiditySlippage from './confirmStableSwapAddLiquiditySlippage'
 import Card from '../../components/Card'
 import StableSwapLiquiditySlippage from '../../components/StableSwapLiquiditySlippage'
-import { getLpTokenUsdEstimate } from '../../utils/stableSwap'
+import { getAuLpSupplyInUsd, getLpTokenUsdEstimate } from '../../utils/stableSwap'
 
 type Props = {
   stableSwapPoolName: StableSwapPoolName
@@ -52,7 +52,7 @@ export default function StableSwapPoolAddLiquidityImpl({ stableSwapPoolName }: P
   const { t } = useTranslation()
   const { account, chainId, library } = useActiveWeb3React()
   const [poolData, _userShareData] = useStablePoolsData(stableSwapPoolName)
-  const { disableAddLiquidity, friendlyName, virtualPrice } = poolData
+  const { disableAddLiquidity, friendlyName, virtualPrice, name } = poolData
   const [allowedSlippage] = useUserSlippageTolerance()
   const { isBonus, isHighImpact, minToMint, priceImpact } = useAddLiquidityPriceImpact(stableSwapPoolName, virtualPrice)
 
@@ -159,7 +159,7 @@ export default function StableSwapPoolAddLiquidityImpl({ stableSwapPoolName }: P
     const { virtualPrice, lpToken, avgExchangeRate } = poolData
     const usdEstimate =
       virtualPrice && minToMint && lpToken
-        ? getLpTokenUsdEstimate(virtualPrice, minToMint, lpToken, avgExchangeRate)
+        ? getLpTokenUsdEstimate(virtualPrice, minToMint, lpToken, name, avgExchangeRate)
         : null
 
     if (!minToMint) {

--- a/src/pages/StableSwapPoolAddLiquidity/StableSwapPoolAddLiquidityImpl.tsx
+++ b/src/pages/StableSwapPoolAddLiquidity/StableSwapPoolAddLiquidityImpl.tsx
@@ -42,7 +42,7 @@ import { AddRemoveTabs } from '../../components/NavigationTabs'
 import confirmStableSwapAddLiquiditySlippage from './confirmStableSwapAddLiquiditySlippage'
 import Card from '../../components/Card'
 import StableSwapLiquiditySlippage from '../../components/StableSwapLiquiditySlippage'
-import { getAuLpSupplyInUsd, getLpTokenUsdEstimate } from '../../utils/stableSwap'
+import { getLpTokenUsdEstimate } from '../../utils/stableSwap'
 
 type Props = {
   stableSwapPoolName: StableSwapPoolName
@@ -156,11 +156,8 @@ export default function StableSwapPoolAddLiquidityImpl({ stableSwapPoolName }: P
     .join('')}`
 
   const modalHeader = () => {
-    const { virtualPrice, lpToken, avgExchangeRate } = poolData
-    const usdEstimate =
-      virtualPrice && minToMint && lpToken
-        ? getLpTokenUsdEstimate(virtualPrice, minToMint, lpToken, name, avgExchangeRate)
-        : null
+    const { virtualPrice, lpToken, lpTokenPriceUSDC } = poolData
+    const usdEstimate = virtualPrice && minToMint && lpToken ? getLpTokenUsdEstimate(lpTokenPriceUSDC, minToMint) : null
 
     if (!minToMint) {
       return null

--- a/src/pages/StableSwapPoolRemoveLiquidity/StableSwapPoolRemoveLiquidityImpl.tsx
+++ b/src/pages/StableSwapPoolRemoveLiquidity/StableSwapPoolRemoveLiquidityImpl.tsx
@@ -37,7 +37,7 @@ import BackButton from '../../components/BackButton'
 import useRemoveLiquidityPriceImpact from '../../hooks/useRemoveLiquidityPriceImpact'
 import StableSwapLiquiditySlippage from '../../components/StableSwapLiquiditySlippage'
 import { useStableSwapContract } from '../../hooks/useContract'
-import { getLpTokenUsdEstimate, getAuLpSupplyInUsd } from '../../utils/stableSwap'
+import { getLpTokenUsdEstimate } from '../../utils/stableSwap'
 
 const INPUT_CHAR_LIMIT = 18
 
@@ -55,7 +55,7 @@ export default function StableSwapPoolAddLiquidity({ stableSwapPoolName }: Props
   const [withdrawTokenIndex, setWithdrawTokenIndex] = useState<number | null>(null)
   const withdrawTokenIndexRef = useRef(withdrawTokenIndex)
   const [poolData, userShareData] = useStablePoolsData(stableSwapPoolName)
-  const { friendlyName, unwrappedTokens, virtualPrice, avgExchangeRate } = poolData
+  const { friendlyName, unwrappedTokens, virtualPrice, lpTokenPriceUSDC } = poolData
   const pool = STABLESWAP_POOLS[stableSwapPoolName]
   const { address, lpToken, metaSwapAddresses } = pool
   const effectiveAddress = isMetaPool(stableSwapPoolName) ? metaSwapAddresses : address
@@ -258,9 +258,7 @@ export default function StableSwapPoolAddLiquidity({ stableSwapPoolName }: Props
 
   const hasZeroInput = JSBI.equal(parsedAmount?.raw ?? BIG_INT_ZERO, BIG_INT_ZERO)
   const usdEstimate =
-    virtualPrice != null && parsedAmount != null
-      ? getLpTokenUsdEstimate(virtualPrice, parsedAmount, lpToken, pool.name, avgExchangeRate)
-      : null
+    virtualPrice != null && parsedAmount != null ? getLpTokenUsdEstimate(lpTokenPriceUSDC, parsedAmount) : null
 
   const insufficientBalanceError =
     parsedAmount != null &&

--- a/src/pages/StableSwapPoolRemoveLiquidity/StableSwapPoolRemoveLiquidityImpl.tsx
+++ b/src/pages/StableSwapPoolRemoveLiquidity/StableSwapPoolRemoveLiquidityImpl.tsx
@@ -37,7 +37,7 @@ import BackButton from '../../components/BackButton'
 import useRemoveLiquidityPriceImpact from '../../hooks/useRemoveLiquidityPriceImpact'
 import StableSwapLiquiditySlippage from '../../components/StableSwapLiquiditySlippage'
 import { useStableSwapContract } from '../../hooks/useContract'
-import { getLpTokenUsdEstimate } from '../../utils/stableSwap'
+import { getLpTokenUsdEstimate, getAuLpSupplyInUsd } from '../../utils/stableSwap'
 
 const INPUT_CHAR_LIMIT = 18
 
@@ -259,7 +259,7 @@ export default function StableSwapPoolAddLiquidity({ stableSwapPoolName }: Props
   const hasZeroInput = JSBI.equal(parsedAmount?.raw ?? BIG_INT_ZERO, BIG_INT_ZERO)
   const usdEstimate =
     virtualPrice != null && parsedAmount != null
-      ? getLpTokenUsdEstimate(virtualPrice, parsedAmount, lpToken, avgExchangeRate)
+      ? getLpTokenUsdEstimate(virtualPrice, parsedAmount, lpToken, pool.name, avgExchangeRate)
       : null
 
   const insufficientBalanceError =

--- a/src/pages/StableSwapPoolRemoveLiquidity/StableSwapPoolRemoveLiquidityImpl.tsx
+++ b/src/pages/StableSwapPoolRemoveLiquidity/StableSwapPoolRemoveLiquidityImpl.tsx
@@ -55,7 +55,7 @@ export default function StableSwapPoolAddLiquidity({ stableSwapPoolName }: Props
   const [withdrawTokenIndex, setWithdrawTokenIndex] = useState<number | null>(null)
   const withdrawTokenIndexRef = useRef(withdrawTokenIndex)
   const [poolData, userShareData] = useStablePoolsData(stableSwapPoolName)
-  const { friendlyName, unwrappedTokens, virtualPrice } = poolData
+  const { friendlyName, unwrappedTokens, virtualPrice, avgExchangeRate } = poolData
   const pool = STABLESWAP_POOLS[stableSwapPoolName]
   const { address, lpToken, metaSwapAddresses } = pool
   const effectiveAddress = isMetaPool(stableSwapPoolName) ? metaSwapAddresses : address
@@ -258,7 +258,9 @@ export default function StableSwapPoolAddLiquidity({ stableSwapPoolName }: Props
 
   const hasZeroInput = JSBI.equal(parsedAmount?.raw ?? BIG_INT_ZERO, BIG_INT_ZERO)
   const usdEstimate =
-    virtualPrice != null && parsedAmount != null ? getLpTokenUsdEstimate(virtualPrice, parsedAmount, lpToken) : null
+    virtualPrice != null && parsedAmount != null
+      ? getLpTokenUsdEstimate(virtualPrice, parsedAmount, lpToken, avgExchangeRate)
+      : null
 
   const insufficientBalanceError =
     parsedAmount != null &&

--- a/src/state/stableswap/constants.ts
+++ b/src/state/stableswap/constants.ts
@@ -1,4 +1,4 @@
-import { ChainId, Token, WETH } from '@trisolaris/sdk'
+import { ChainId, Token, TokenAmount, WETH } from '@trisolaris/sdk'
 import _ from 'lodash'
 import { FRAX, USDC, USDT, WBTC, UST, USN, NUSD, AUUSDC, AUUSDT } from '../../constants/tokens'
 
@@ -30,6 +30,7 @@ export enum StableSwapPoolTypes {
   BTC,
   ETH,
   USD,
+  AURIGAMI,
   OTHER
 }
 
@@ -39,6 +40,8 @@ export function getTokenForStablePoolType(poolType: StableSwapPoolTypes): Token 
   } else if (poolType === StableSwapPoolTypes.ETH) {
     return WETH[ChainId.AURORA]
   } else if (poolType === StableSwapPoolTypes.USD) {
+    return USDC[ChainId.AURORA]
+  } else if (poolType === StableSwapPoolTypes.AURIGAMI) {
     return USDC[ChainId.AURORA]
   } else {
     throw new Error('[getTokenForStablePoolType] Error getting token')
@@ -201,7 +204,7 @@ export const STABLESWAP_POOLS: StableSwapPools = {
     ),
     poolTokens: [AUUSDC[ChainId.AURORA], AUUSDT[ChainId.AURORA]],
     address: '0x46F27692de8aA76E86e7E665e573828b9ddcB2b8',
-    type: StableSwapPoolTypes.USD,
+    type: StableSwapPoolTypes.AURIGAMI,
     route: 'usd',
     isOutdated: false,
     rewardPids: null

--- a/src/utils/stableSwap.ts
+++ b/src/utils/stableSwap.ts
@@ -1,8 +1,18 @@
 import { CurrencyAmount, JSBI, Token, TokenAmount } from '@trisolaris/sdk'
 
-export function getLpTokenUsdEstimate(virtualPrice: TokenAmount, amount: CurrencyAmount, lpToken: Token) {
-  return new TokenAmount(
-    lpToken,
-    JSBI.divide(JSBI.multiply(virtualPrice.raw, amount.raw), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(18)))
-  )
+export function getLpTokenUsdEstimate(
+  virtualPrice: TokenAmount,
+  amount: CurrencyAmount,
+  lpToken: Token,
+  auUSDCExchangeRate?: JSBI | null
+) {
+  return auUSDCExchangeRate
+    ? new TokenAmount(
+        lpToken,
+        JSBI.divide(JSBI.multiply(auUSDCExchangeRate, amount.raw), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(16)))
+      )
+    : new TokenAmount(
+        lpToken,
+        JSBI.divide(JSBI.multiply(virtualPrice.raw, amount.raw), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(18)))
+      )
 }

--- a/src/utils/stableSwap.ts
+++ b/src/utils/stableSwap.ts
@@ -1,28 +1,9 @@
 import { ChainId, CurrencyAmount, JSBI, Token, TokenAmount } from '@trisolaris/sdk'
 import { USDC } from '../constants/tokens'
-import { StableSwapPoolName } from '../state/stableswap/constants'
 
-export function getLpTokenUsdEstimate(
-  virtualPrice: TokenAmount,
-  amount: CurrencyAmount,
-  lpToken: Token,
-  name: string,
-  avgExchangeRate: JSBI
-) {
-  return name === StableSwapPoolName.AUUSDC_AUUSDT
-    ? getAuLpSupplyInUsd(amount, avgExchangeRate)
-    : new TokenAmount(
-        lpToken,
-        JSBI.divide(JSBI.multiply(virtualPrice.raw, amount.raw), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(18)))
-      )
-}
-
-export function getAuLpSupplyInUsd(lpBalance: CurrencyAmount, avgExchangeRate: JSBI) {
+export function getLpTokenUsdEstimate(lpTokenPriceUSDC: TokenAmount, amount: CurrencyAmount) {
   return new TokenAmount(
     USDC[ChainId.AURORA],
-    JSBI.divide(
-      JSBI.multiply(JSBI.divide(lpBalance.raw, JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(10))), avgExchangeRate),
-      JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(18))
-    )
+    JSBI.divide(JSBI.multiply(lpTokenPriceUSDC.raw, amount.raw), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(18)))
   )
 }

--- a/src/utils/stableSwap.ts
+++ b/src/utils/stableSwap.ts
@@ -1,18 +1,28 @@
-import { CurrencyAmount, JSBI, Token, TokenAmount } from '@trisolaris/sdk'
+import { ChainId, CurrencyAmount, JSBI, Token, TokenAmount } from '@trisolaris/sdk'
+import { USDC } from '../constants/tokens'
+import { StableSwapPoolName } from '../state/stableswap/constants'
 
 export function getLpTokenUsdEstimate(
   virtualPrice: TokenAmount,
   amount: CurrencyAmount,
   lpToken: Token,
-  auUSDCExchangeRate?: JSBI | null
+  name: string,
+  avgExchangeRate: JSBI
 ) {
-  return auUSDCExchangeRate
-    ? new TokenAmount(
-        lpToken,
-        JSBI.divide(JSBI.multiply(auUSDCExchangeRate, amount.raw), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(16)))
-      )
+  return name === StableSwapPoolName.AUUSDC_AUUSDT
+    ? getAuLpSupplyInUsd(amount, avgExchangeRate)
     : new TokenAmount(
         lpToken,
         JSBI.divide(JSBI.multiply(virtualPrice.raw, amount.raw), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(18)))
       )
+}
+
+export function getAuLpSupplyInUsd(lpBalance: CurrencyAmount, avgExchangeRate: JSBI) {
+  return new TokenAmount(
+    USDC[ChainId.AURORA],
+    JSBI.divide(
+      JSBI.multiply(JSBI.divide(lpBalance.raw, JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(10))), avgExchangeRate),
+      JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(18))
+    )
+  )
 }


### PR DESCRIPTION
Fixes usd estimations in auUSDC <> auUSDT pool.

- Add auErc20 tokens (Aurigami tokens) ABI and contract hook.
- Add call for getting auUSDT and auUSDC exchange rates.
- Add calculations for getting the usd quivalent of auerc20 amounts using exchange rates.
- Add totalLockedInUsd field in useStablePoolsData hook for returning the calculated $tvl value of supply for  auUSDC <> auUSDT pool (For the rest of the pols, returns the same as before)

### Before:
#### Tvl / User deposits:
<img width="723" alt="Screen Shot 2022-09-12 at 09 42 28" src="https://user-images.githubusercontent.com/96993065/189599375-0e6b4357-5792-4948-80ee-d963f1b17def.png">

#### Adding Liquidity: 
<img width="418" alt="Screen Shot 2022-09-12 at 09 42 11" src="https://user-images.githubusercontent.com/96993065/189599370-b3b32219-2c48-458d-a435-ad645c5eb725.png">

#### Removing Liquidity:
<img width="695" alt="Screen Shot 2022-09-12 at 09 42 41" src="https://user-images.githubusercontent.com/96993065/189599402-ea713501-80b4-4ded-a9b2-11b4825b853b.png">

### After:
#### Tvl / User deposits:
<img width="775" alt="Screen Shot 2022-09-12 at 09 34 38" src="https://user-images.githubusercontent.com/96993065/189599100-0dcb5a84-4fbc-4c41-b5aa-2860d880de13.png">

#### Adding Liquidity: 
<img width="443" alt="Screen Shot 2022-09-12 at 09 36 23" src="https://user-images.githubusercontent.com/96993065/189599135-08eac31d-c0ee-4f60-9699-9ddfce388b26.png">

#### Removing Liquidity:
<img width="753" alt="Screen Shot 2022-09-12 at 09 34 58" src="https://user-images.githubusercontent.com/96993065/189599132-082a0bba-665f-422f-9bc8-2627fe86a18b.png">

