### PR TITLE
Remove farms groups

### DIFF
--- a/src/pages/EarnTri/EarnTri.tsx
+++ b/src/pages/EarnTri/EarnTri.tsx
@@ -68,6 +68,8 @@ export default function EarnTri() {
                     friendlyFarmName={farm.friendlyFarmName}
                     isFeatured={farm.isFeatured}
                     poolType={farm.poolType}
+                    lpAddress={farm.lpAddress}
+                    poolId={farm.poolId}
                   />
                 )
               )}
@@ -110,6 +112,8 @@ export default function EarnTri() {
                   friendlyFarmName={farm.friendlyFarmName}
                   stableSwapPoolName={farm.stableSwapPoolName}
                   poolType={farm.poolType}
+                  lpAddress={farm.lpAddress}
+                  poolId={farm.poolId}
                 />
               ))}
             </>

--- a/src/pages/EarnTri/EarnTri.tsx
+++ b/src/pages/EarnTri/EarnTri.tsx
@@ -45,48 +45,32 @@ export default function EarnTri() {
         sortBy={sortBy}
       />
 
-      {!hasSearchQuery && !activeFarmsFilter && (
-        <AutoColumn gap="md" style={{ width: '100%' }}>
-          <DataRow style={{ alignItems: 'baseline' }}>
-            <TYPE.mediumHeader style={{ marginTop: '0.5rem' }}>Stable Pools</TYPE.mediumHeader>
-          </DataRow>
-          <PoolSection>
-            {stablePoolFarms.map(farm =>
-              farm.stableSwapPoolName == null ? null : (
-                <MemoizedPoolCardTRI
-                  key={farm.ID}
-                  apr={farm.apr}
-                  nonTriAPRs={farm.nonTriAPRs}
-                  chefVersion={farm.chefVersion}
-                  isPeriodFinished={farm.isPeriodFinished}
-                  tokens={farm.tokens}
-                  stableSwapPoolName={farm.stableSwapPoolName}
-                  totalStakedInUSD={farm.totalStakedInUSD}
-                  version={farm.ID}
-                  hasNonTriRewards={farm.hasNonTriRewards}
-                  inStaging={farm.inStaging}
-                  noTriRewards={farm.noTriRewards}
-                  isStaking={isTokenAmountPositive(farm.stakedAmount)}
-                  friendlyFarmName={farm.friendlyFarmName}
-                  isFeatured={farm.isFeatured}
-                  poolType={farm.poolType}
-                  lpAddress={farm.lpAddress}
-                  poolId={farm.poolId}
-                />
-              )
-            )}
-          </PoolSection>
-        </AutoColumn>
-      )}
-
       <AutoColumn gap="md" style={{ width: '100%' }}>
-        {!hasSearchQuery && !activeFarmsFilter && (
-          <>
-            <DataRow style={{ alignItems: 'baseline' }}>
-              <TYPE.mediumHeader style={{ marginTop: '0.5rem' }}>Dual Rewards Pools</TYPE.mediumHeader>
-            </DataRow>
-
-            <PoolSection>
+        <PoolSection>
+          {!hasSearchQuery && !activeFarmsFilter && (
+            <>
+              {stablePoolFarms.map(farm =>
+                farm.stableSwapPoolName == null ? null : (
+                  <MemoizedPoolCardTRI
+                    key={farm.ID}
+                    apr={farm.apr}
+                    nonTriAPRs={farm.nonTriAPRs}
+                    chefVersion={farm.chefVersion}
+                    isPeriodFinished={farm.isPeriodFinished}
+                    tokens={farm.tokens}
+                    stableSwapPoolName={farm.stableSwapPoolName}
+                    totalStakedInUSD={farm.totalStakedInUSD}
+                    version={farm.ID}
+                    hasNonTriRewards={farm.hasNonTriRewards}
+                    inStaging={farm.inStaging}
+                    noTriRewards={farm.noTriRewards}
+                    isStaking={isTokenAmountPositive(farm.stakedAmount)}
+                    friendlyFarmName={farm.friendlyFarmName}
+                    isFeatured={farm.isFeatured}
+                    poolType={farm.poolType}
+                  />
+                )
+              )}
               {dualRewardPools.map(farm => (
                 <MemoizedPoolCardTRI
                   key={farm.ID}
@@ -109,18 +93,27 @@ export default function EarnTri() {
                   poolId={farm.poolId}
                 />
               ))}
-            </PoolSection>
-          </>
-        )}
-      </AutoColumn>
-      <AutoColumn gap="md" style={{ width: '100%' }}>
-        {!hasSearchQuery && !activeFarmsFilter && (
-          <DataRow style={{ alignItems: 'baseline' }}>
-            <TYPE.mediumHeader style={{ marginTop: '0.5rem' }}>TRI Pools</TYPE.mediumHeader>
-          </DataRow>
-        )}
-
-        <PoolSection>
+              {nonTriFarms.map(farm => (
+                <MemoizedPoolCardTRI
+                  key={farm.ID}
+                  apr={farm.apr}
+                  nonTriAPRs={farm.nonTriAPRs}
+                  chefVersion={farm.chefVersion}
+                  isPeriodFinished={farm.isPeriodFinished}
+                  tokens={farm.tokens}
+                  totalStakedInUSD={farm.totalStakedInUSD}
+                  version={farm.ID}
+                  hasNonTriRewards={farm.hasNonTriRewards}
+                  inStaging={farm.inStaging}
+                  noTriRewards={farm.noTriRewards}
+                  isStaking={isTokenAmountPositive(farm.stakedAmount)}
+                  friendlyFarmName={farm.friendlyFarmName}
+                  stableSwapPoolName={farm.stableSwapPoolName}
+                  poolType={farm.poolType}
+                />
+              ))}
+            </>
+          )}
           {filteredFarms.map(farm => (
             <MemoizedPoolCardTRI
               key={farm.ID}
@@ -144,39 +137,6 @@ export default function EarnTri() {
             />
           ))}
         </PoolSection>
-      </AutoColumn>
-      <AutoColumn gap="md" style={{ width: '100%' }}>
-        {!hasSearchQuery && !activeFarmsFilter && (
-          <>
-            <DataRow style={{ alignItems: 'baseline' }}>
-              <TYPE.mediumHeader style={{ marginTop: '0.5rem' }}>Ecosystem Pools</TYPE.mediumHeader>
-            </DataRow>
-
-            <PoolSection>
-              {nonTriFarms.map(farm => (
-                <MemoizedPoolCardTRI
-                  key={farm.ID}
-                  apr={farm.apr}
-                  nonTriAPRs={farm.nonTriAPRs}
-                  chefVersion={farm.chefVersion}
-                  isPeriodFinished={farm.isPeriodFinished}
-                  tokens={farm.tokens}
-                  totalStakedInUSD={farm.totalStakedInUSD}
-                  version={farm.ID}
-                  hasNonTriRewards={farm.hasNonTriRewards}
-                  inStaging={farm.inStaging}
-                  noTriRewards={farm.noTriRewards}
-                  isStaking={isTokenAmountPositive(farm.stakedAmount)}
-                  friendlyFarmName={farm.friendlyFarmName}
-                  stableSwapPoolName={farm.stableSwapPoolName}
-                  poolType={farm.poolType}
-                  lpAddress={farm.lpAddress}
-                  poolId={farm.poolId}
-                />
-              ))}
-            </PoolSection>
-          </>
-        )}
       </AutoColumn>
       {!hasSearchQuery && !activeFarmsFilter && (
         <AutoColumn gap="md" style={{ width: '100%' }}>


### PR DESCRIPTION
-Removes farms groupings, due to now the pool type being in the card itself
-Only leaves legacy farms and it's toggle as a separate group

<img width="996" alt="Screen Shot 2022-09-14 at 17 06 21" src="https://user-images.githubusercontent.com/96993065/190192491-4322d8df-ea6d-44dd-97ee-84f613089200.png">
<img width="985" alt="Screen Shot 2022-09-14 at 17 01 14" src="https://user-images.githubusercontent.com/96993065/190191479-a49b78db-b5b3-481f-9e4f-cac4317969a9.png">
<img width="853" alt="Screen Shot 2022-09-14 at 17 01 21" src="https://user-images.githubusercontent.com/96993065/190191508-109be6c3-f301-4a21-ae5b-ec57cb87ad3f.png">
