### PR TITLE
Add mobile min-height for cards height consistency

### DIFF
--- a/src/components/earn/PoolCardTri/PoolCardTri.styles.tsx
+++ b/src/components/earn/PoolCardTri/PoolCardTri.styles.tsx
@@ -40,6 +40,7 @@ export const Wrapper = styled(Card)<{
   ${({ theme }) => theme.mediaWidth.upToSmall`
         padding-left: 10px;
         padding-right: 10px;
+        min-height: 73px;
     `};
 `
 


### PR DESCRIPTION
Described in title

### Before:
<img width="339" alt="Screen Shot 2022-09-15 at 12 29 48" src="https://user-images.githubusercontent.com/96993065/190382424-77c03b34-0cc0-4d33-bfe8-d6996ad3fad9.png">

### After:
<img width="335" alt="Screen Shot 2022-09-15 at 12 31 25" src="https://user-images.githubusercontent.com/96993065/190382434-4d178ded-0baf-4109-80ba-d14328b42eda.png">
