### PR TITLE
Remove rewarder address from tri-aurora

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "interface",
   "description": "Trisolaris Interface",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "homepage": ".",
   "private": true,
   "devDependencies": {

--- a/src/state/stake/stake-constants.ts
+++ b/src/state/stake/stake-constants.ts
@@ -255,7 +255,6 @@ const AURORA_POOLS: StakingTri[] = [
     poolId: 1,
     tokens: [TRI[ChainId.AURORA], AURORA[ChainId.AURORA]],
     lpAddress: '0xd1654a7713617d41A8C9530Fb9B948d00e162194',
-    rewarderAddress: '0x78EdEeFdF8c3ad827228d07018578E89Cf159Df1',
     allocPoint: 1,
     isFeatured: true
   }),


### PR DESCRIPTION
Removing AURORA rewarder from TRI<>AURORA farm.

Before: 

<img width="403" alt="Screen Shot 2022-09-17 at 15 21 00" src="https://user-images.githubusercontent.com/96993065/190859093-c5337e34-7ff8-45bd-ada4-15f16e3bbae7.png">

After:

<img width="412" alt="Screen Shot 2022-09-17 at 15 19 38" src="https://user-images.githubusercontent.com/96993065/190859086-9741e7fe-adc0-4434-94c5-1ade78ae5f33.png">

<img width="752" alt="Screen Shot 2022-09-17 at 15 19 34" src="https://user-images.githubusercontent.com/96993065/190859084-118943d4-deb0-42fc-a087-1d5a8f71541e.png">
