### PR TITLE
B/rework stablepoolsdata

### DIFF
--- a/src/components/PositionCard/StablePositionCard/index.tsx
+++ b/src/components/PositionCard/StablePositionCard/index.tsx
@@ -144,7 +144,9 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
     push(`${pathname}/remove/${name}`)
   }
 
-  const poolTVL = stablePoolData.totalLockedInUsd?.toFixed(0)
+  // const poolTVL = stablePoolData.totalLockedInUsd?.toFixed(0)
+  const poolTVL = stablePoolData.totalLocked?.toFixed(0)
+
   const formattedPoolData = [
     {
       label: 'Virtual Price',

--- a/src/components/PositionCard/StablePositionCard/index.tsx
+++ b/src/components/PositionCard/StablePositionCard/index.tsx
@@ -1,4 +1,4 @@
-import { Pair } from '@trisolaris/sdk'
+import { JSBI, Pair } from '@trisolaris/sdk'
 import { darken } from 'polished'
 import React, { useState, useContext } from 'react'
 import { Text } from 'rebass'
@@ -144,8 +144,8 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
     push(`${pathname}/remove/${name}`)
   }
 
-  // const poolTVL = stablePoolData.totalLockedInUsd?.toFixed(0)
-  const poolTVL = stablePoolData.totalLocked?.toFixed(0)
+  const reserve = stablePoolData.reserve
+  const poolTVL = reserve?.greaterThan(JSBI.BigInt(1000)) ? reserve?.toFixed(0) : reserve?.toFixed(2) // Avoid rounding down on small tvl numbers
 
   const formattedPoolData = [
     {

--- a/src/hooks/useStablePoolsData.ts
+++ b/src/hooks/useStablePoolsData.ts
@@ -15,7 +15,7 @@ import { useSingleCallResult, useSingleContractMultipleData } from '../state/mul
 import { useTokenBalance } from '../state/wallet/hooks'
 import { useTotalSupply } from '../data/TotalSupply'
 import { BIG_INT_ZERO, ZERO_ADDRESS } from '../constants'
-import { USDC, AUUSDC, AUUSDT } from '../constants/tokens'
+import { USDC, AUUSDC, AUUSDT, USDT } from '../constants/tokens'
 import useGetTokenPrice from './useGetTokenPrice'
 import { dummyToken, tokenAmount } from '../state/stake/stake-constants'
 
@@ -143,11 +143,13 @@ export default function useStablePoolsData(poolName: StableSwapPoolName): PoolDa
     const balance = tokenBalances[i]
     const tokenPrice = tokenPrices[i]
 
-    // WIP: exp to 1e18 for non auriagami tokens, until figuring out working with Price
-    const poolAssetPrice =
-      pool.name === StableSwapPoolName.AUUSDC_AUUSDT
-        ? JSBI.multiply(tokenPrice?.raw.numerator ?? JSBI.BigInt(1), decimalDelta)
-        : JSBI.multiply(JSBI.BigInt(1), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(18)))
+    const poolAssetPrice = JSBI.divide(
+      JSBI.multiply(
+        tokenPrice?.adjusted.numerator ?? JSBI.BigInt(1),
+        JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(18))
+      ),
+      tokenPrice?.adjusted.denominator ?? JSBI.BigInt(1)
+    )
 
     const tokenBalanceNormalized = normalizeTokenBalance(token, balance)
 

--- a/src/hooks/useStablePoolsData.ts
+++ b/src/hooks/useStablePoolsData.ts
@@ -6,18 +6,16 @@ import {
   getTokenForStablePoolType,
   isMetaPool,
   StableSwapPoolName,
-  StableSwapPoolTypes,
   STABLESWAP_POOLS
 } from '../state/stableswap/constants'
-import { useStableSwapContract, useStableSwapMetaPool, useAuTokenContract } from './useContract'
-import { ChainId, JSBI, Percent, Price, Token, TokenAmount, WETH } from '@trisolaris/sdk'
+import { useStableSwapContract, useStableSwapMetaPool } from './useContract'
+import { ChainId, JSBI, Percent, Token, TokenAmount } from '@trisolaris/sdk'
 import { useSingleCallResult, useSingleContractMultipleData } from '../state/multicall/hooks'
 import { useTokenBalance } from '../state/wallet/hooks'
 import { useTotalSupply } from '../data/TotalSupply'
 import { BIG_INT_ZERO, ZERO_ADDRESS } from '../constants'
-import { USDC, AUUSDC, AUUSDT, USDT } from '../constants/tokens'
+import { USDC } from '../constants/tokens'
 import useGetTokenPrice from './useGetTokenPrice'
-import { dummyToken, tokenAmount } from '../state/stake/stake-constants'
 
 const STABLE_POOL_CONTRACT_DECIMALS = 18
 interface TokenShareType {
@@ -42,7 +40,6 @@ export interface StablePoolDataType {
   lpTokenPriceUSDC: TokenAmount
   lpToken: Token | null
   disableAddLiquidity: boolean
-  avgExchangeRate: JSBI
 }
 
 export interface UserShareType {
@@ -58,17 +55,6 @@ export type PoolDataHookReturnType = [StablePoolDataType, UserShareType | null]
 
 export default function useStablePoolsData(poolName: StableSwapPoolName): PoolDataHookReturnType {
   const { account } = useActiveWeb3React()
-
-  const auUSDCContract = useAuTokenContract(AUUSDC[ChainId.AURORA].address)
-  const auUSDTContract = useAuTokenContract(AUUSDT[ChainId.AURORA].address)
-
-  const auUSDCExchangeRate: JSBI = JSBI.BigInt(
-    useSingleCallResult(auUSDCContract, 'exchangeRateStored')?.result?.[0] ?? 0
-  )
-  const auUSDTExchangeRate: JSBI = JSBI.BigInt(
-    useSingleCallResult(auUSDTContract, 'exchangeRateStored')?.result?.[0] ?? 0
-  )
-  const avgExchangeRate = JSBI.divide(JSBI.ADD(auUSDCExchangeRate, auUSDTExchangeRate), JSBI.BigInt(2))
 
   const pool = STABLESWAP_POOLS[poolName]
   const { disableAddLiquidity, lpToken, poolTokens, type, underlyingPoolTokens } = pool
@@ -207,8 +193,7 @@ export default function useStablePoolsData(poolName: StableSwapPoolName): PoolDa
     lpTokenPriceUSDC,
     lpToken,
     isPaused,
-    disableAddLiquidity: disableAddLiquidity ?? false,
-    avgExchangeRate: avgExchangeRate
+    disableAddLiquidity: disableAddLiquidity ?? false
   }
 
   // User Data

--- a/src/hooks/useUSDCPrice.ts
+++ b/src/hooks/useUSDCPrice.ts
@@ -84,12 +84,22 @@ export default function useUSDCPrice(currency?: Currency): Price | undefined {
     }
     // handle usdc
     if (wrapped.equals(USDC)) {
-      return new Price(USDC, USDC, '1', '1')
+      return new Price(
+        USDC,
+        USDC,
+        JSBI.multiply(JSBI.BigInt(1), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(wrapped.decimals))),
+        '1'
+      )
     }
 
     // handle usdt
     if (wrapped.equals(USDT)) {
-      return new Price(USDT, USDT, '1', '1')
+      return new Price(
+        USDT,
+        USDT,
+        JSBI.multiply(JSBI.BigInt(1), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(wrapped.decimals))),
+        '1'
+      )
     }
 
     // handle Aurigami exchange rates

--- a/src/hooks/useUSDCPrice.ts
+++ b/src/hooks/useUSDCPrice.ts
@@ -1,12 +1,14 @@
 // TODO: Actually calculate price
 
-import { ChainId, Currency, currencyEquals, JSBI, Price, WETH } from '@trisolaris/sdk'
+import { ChainId, Currency, currencyEquals, JSBI, Price, TokenAmount, WETH } from '@trisolaris/sdk'
 import { useMemo } from 'react'
 import { BIG_INT_ZERO } from '../constants'
-import { USDC as usdcDef, USDT as usdtDef } from '../constants/tokens'
+import { AUUSDC as auUsdcDef, AUUSDT as auUsdtDef, USDC as usdcDef, USDT as usdtDef } from '../constants/tokens'
 import { PairState, usePairs } from '../data/Reserves'
 import { useActiveWeb3React } from '.'
 import { wrappedCurrency } from '../utils/wrappedCurrency'
+import { useAuTokenContract } from './useContract'
+import { useSingleCallResult } from '../state/multicall/hooks'
 
 /**
  * Returns the price in USDC of the input currency
@@ -18,6 +20,18 @@ export default function useUSDCPrice(currency?: Currency): Price | undefined {
 
   const USDC = chainId ? usdcDef[chainId] : usdcDef[ChainId.AURORA]
   const USDT = chainId ? usdtDef[chainId] : usdtDef[ChainId.AURORA]
+  const AUUSDT = chainId ? auUsdtDef[chainId] : auUsdtDef[ChainId.AURORA]
+  const AUUSDC = chainId ? auUsdcDef[chainId] : auUsdcDef[ChainId.AURORA]
+
+  const auUSDCContract = useAuTokenContract(AUUSDC.address)
+  const auUSDTContract = useAuTokenContract(AUUSDT.address)
+
+  const auUSDCExchangeRate: JSBI = JSBI.BigInt(
+    useSingleCallResult(auUSDCContract, 'exchangeRateStored')?.result?.[0] ?? 0
+  )
+  const auUSDTExchangeRate: JSBI = JSBI.BigInt(
+    useSingleCallResult(auUSDTContract, 'exchangeRateStored')?.result?.[0] ?? 0
+  )
 
   const tokenPairs: [Currency | undefined, Currency | undefined][] = useMemo(
     () => [
@@ -33,6 +47,26 @@ export default function useUSDCPrice(currency?: Currency): Price | undefined {
   const [[currencyEthState, currencyEth], [usdcPairState, usdcPair], [usdcEthPairState, usdcEthPair]] = usePairs(
     tokenPairs
   )
+
+  const calculateAuUSDCExchangeRate = useMemo(() => {
+    return JSBI.divide(
+      JSBI.multiply(
+        JSBI.multiply(JSBI.BigInt(1), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(8))), // need to escalate up/down the amount to 1e8 to calculate * exchange rato
+        auUSDCExchangeRate
+      ),
+      JSBI.multiply(JSBI.BigInt(1), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(18)))
+    )
+  }, [auUSDCExchangeRate])
+
+  const calculateAuUSDTExchangeRate = useMemo(() => {
+    return JSBI.divide(
+      JSBI.multiply(
+        JSBI.multiply(JSBI.BigInt(1), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(8))), // need to escalate up/down the amount to 1e8 to calculate * exchange rato
+        auUSDTExchangeRate
+      ),
+      JSBI.multiply(JSBI.BigInt(1), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(18)))
+    )
+  }, [auUSDTExchangeRate])
 
   return useMemo(() => {
     if (!currency || !wrapped || !chainId) {
@@ -56,6 +90,17 @@ export default function useUSDCPrice(currency?: Currency): Price | undefined {
     // handle usdt
     if (wrapped.equals(USDT)) {
       return new Price(USDT, USDT, '1', '1')
+    }
+
+    // handle Aurigami exchange rates
+    if (wrapped.equals(AUUSDC) || wrapped.equals(AUUSDT)) {
+      const exchangeRate = wrapped.equals(AUUSDC) ? calculateAuUSDCExchangeRate : calculateAuUSDTExchangeRate
+      return new Price(
+        wrapped,
+        USDC,
+        JSBI.multiply(JSBI.BigInt(1), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(wrapped.decimals))),
+        exchangeRate
+      )
     }
 
     const currencyEthPairWETHAmount = currencyEth?.reserveOf(WETH[chainId])

--- a/src/hooks/useUSDCPrice.ts
+++ b/src/hooks/useUSDCPrice.ts
@@ -88,7 +88,7 @@ export default function useUSDCPrice(currency?: Currency): Price | undefined {
         USDC,
         USDC,
         JSBI.multiply(JSBI.BigInt(1), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(wrapped.decimals))),
-        '1'
+        JSBI.multiply(JSBI.BigInt(1), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(wrapped.decimals)))
       )
     }
 
@@ -96,9 +96,9 @@ export default function useUSDCPrice(currency?: Currency): Price | undefined {
     if (wrapped.equals(USDT)) {
       return new Price(
         USDT,
-        USDT,
+        USDC,
         JSBI.multiply(JSBI.BigInt(1), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(wrapped.decimals))),
-        '1'
+        JSBI.multiply(JSBI.BigInt(1), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(wrapped.decimals)))
       )
     }
 

--- a/src/pages/StableSwapPoolAddLiquidity/StableSwapPoolAddLiquidityImpl.tsx
+++ b/src/pages/StableSwapPoolAddLiquidity/StableSwapPoolAddLiquidityImpl.tsx
@@ -42,7 +42,7 @@ import { AddRemoveTabs } from '../../components/NavigationTabs'
 import confirmStableSwapAddLiquiditySlippage from './confirmStableSwapAddLiquiditySlippage'
 import Card from '../../components/Card'
 import StableSwapLiquiditySlippage from '../../components/StableSwapLiquiditySlippage'
-import { getAuLpSupplyInUsd, getLpTokenUsdEstimate } from '../../utils/stableSwap'
+import { getLpTokenUsdEstimate } from '../../utils/stableSwap'
 
 type Props = {
   stableSwapPoolName: StableSwapPoolName
@@ -156,11 +156,8 @@ export default function StableSwapPoolAddLiquidityImpl({ stableSwapPoolName }: P
     .join('')}`
 
   const modalHeader = () => {
-    const { virtualPrice, lpToken, avgExchangeRate } = poolData
-    const usdEstimate =
-      virtualPrice && minToMint && lpToken
-        ? getLpTokenUsdEstimate(virtualPrice, minToMint, lpToken, name, avgExchangeRate)
-        : null
+    const { virtualPrice, lpToken, lpTokenPriceUSDC } = poolData
+    const usdEstimate = virtualPrice && minToMint && lpToken ? getLpTokenUsdEstimate(lpTokenPriceUSDC, minToMint) : null
 
     if (!minToMint) {
       return null

--- a/src/pages/StableSwapPoolRemoveLiquidity/StableSwapPoolRemoveLiquidityImpl.tsx
+++ b/src/pages/StableSwapPoolRemoveLiquidity/StableSwapPoolRemoveLiquidityImpl.tsx
@@ -37,7 +37,7 @@ import BackButton from '../../components/BackButton'
 import useRemoveLiquidityPriceImpact from '../../hooks/useRemoveLiquidityPriceImpact'
 import StableSwapLiquiditySlippage from '../../components/StableSwapLiquiditySlippage'
 import { useStableSwapContract } from '../../hooks/useContract'
-import { getLpTokenUsdEstimate, getAuLpSupplyInUsd } from '../../utils/stableSwap'
+import { getLpTokenUsdEstimate } from '../../utils/stableSwap'
 
 const INPUT_CHAR_LIMIT = 18
 
@@ -55,7 +55,7 @@ export default function StableSwapPoolAddLiquidity({ stableSwapPoolName }: Props
   const [withdrawTokenIndex, setWithdrawTokenIndex] = useState<number | null>(null)
   const withdrawTokenIndexRef = useRef(withdrawTokenIndex)
   const [poolData, userShareData] = useStablePoolsData(stableSwapPoolName)
-  const { friendlyName, unwrappedTokens, virtualPrice, avgExchangeRate } = poolData
+  const { friendlyName, unwrappedTokens, virtualPrice, lpTokenPriceUSDC } = poolData
   const pool = STABLESWAP_POOLS[stableSwapPoolName]
   const { address, lpToken, metaSwapAddresses } = pool
   const effectiveAddress = isMetaPool(stableSwapPoolName) ? metaSwapAddresses : address
@@ -258,9 +258,7 @@ export default function StableSwapPoolAddLiquidity({ stableSwapPoolName }: Props
 
   const hasZeroInput = JSBI.equal(parsedAmount?.raw ?? BIG_INT_ZERO, BIG_INT_ZERO)
   const usdEstimate =
-    virtualPrice != null && parsedAmount != null
-      ? getLpTokenUsdEstimate(virtualPrice, parsedAmount, lpToken, pool.name, avgExchangeRate)
-      : null
+    virtualPrice != null && parsedAmount != null ? getLpTokenUsdEstimate(lpTokenPriceUSDC, parsedAmount) : null
 
   const insufficientBalanceError =
     parsedAmount != null &&

--- a/src/state/stableswap/constants.ts
+++ b/src/state/stableswap/constants.ts
@@ -1,4 +1,4 @@
-import { ChainId, Token, WETH } from '@trisolaris/sdk'
+import { ChainId, Token, TokenAmount, WETH } from '@trisolaris/sdk'
 import _ from 'lodash'
 import { FRAX, USDC, USDT, WBTC, UST, USN, NUSD, AUUSDC, AUUSDT } from '../../constants/tokens'
 
@@ -30,6 +30,7 @@ export enum StableSwapPoolTypes {
   BTC,
   ETH,
   USD,
+  AURIGAMI,
   OTHER
 }
 
@@ -39,6 +40,8 @@ export function getTokenForStablePoolType(poolType: StableSwapPoolTypes): Token 
   } else if (poolType === StableSwapPoolTypes.ETH) {
     return WETH[ChainId.AURORA]
   } else if (poolType === StableSwapPoolTypes.USD) {
+    return USDC[ChainId.AURORA]
+  } else if (poolType === StableSwapPoolTypes.AURIGAMI) {
     return USDC[ChainId.AURORA]
   } else {
     throw new Error('[getTokenForStablePoolType] Error getting token')
@@ -201,7 +204,7 @@ export const STABLESWAP_POOLS: StableSwapPools = {
     ),
     poolTokens: [AUUSDC[ChainId.AURORA], AUUSDT[ChainId.AURORA]],
     address: '0x46F27692de8aA76E86e7E665e573828b9ddcB2b8',
-    type: StableSwapPoolTypes.USD,
+    type: StableSwapPoolTypes.AURIGAMI,
     route: 'usd',
     isOutdated: false,
     rewardPids: null

--- a/src/utils/stableSwap.ts
+++ b/src/utils/stableSwap.ts
@@ -1,6 +1,6 @@
 import { ChainId, CurrencyAmount, JSBI, Token, TokenAmount } from '@trisolaris/sdk'
 import { USDC } from '../constants/tokens'
-import { StableSwapPoolName } from '../state/stableswap/constants'
+import { StableSwapPoolName, StableSwapPoolTypes } from '../state/stableswap/constants'
 
 export function getLpTokenUsdEstimate(
   virtualPrice: TokenAmount,
@@ -25,4 +25,29 @@ export function getAuLpSupplyInUsd(lpBalance: CurrencyAmount, avgExchangeRate: J
       JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(18))
     )
   )
+}
+
+export function getBalanceConversionForStablePoolType(
+  poolType: StableSwapPoolTypes,
+  balance: JSBI,
+  token: Token,
+  exchangeRate: JSBI
+): TokenAmount {
+  if (
+    poolType === StableSwapPoolTypes.BTC ||
+    poolType === StableSwapPoolTypes.ETH ||
+    poolType === StableSwapPoolTypes.USD
+  ) {
+    return new TokenAmount(token, balance)
+  } else if (poolType === StableSwapPoolTypes.AURIGAMI) {
+    return new TokenAmount(
+      token,
+      JSBI.divide(
+        JSBI.multiply(JSBI.BigInt(balance), exchangeRate),
+        JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(18))
+      )
+    )
+  } else {
+    throw new Error('[getTokenForStablePoolType] Error getting tokenAmount conversion')
+  }
 }

--- a/src/utils/stableSwap.ts
+++ b/src/utils/stableSwap.ts
@@ -1,53 +1,9 @@
 import { ChainId, CurrencyAmount, JSBI, Token, TokenAmount } from '@trisolaris/sdk'
 import { USDC } from '../constants/tokens'
-import { StableSwapPoolName, StableSwapPoolTypes } from '../state/stableswap/constants'
 
-export function getLpTokenUsdEstimate(
-  virtualPrice: TokenAmount,
-  amount: CurrencyAmount,
-  lpToken: Token,
-  name: string,
-  avgExchangeRate: JSBI
-) {
-  return name === StableSwapPoolName.AUUSDC_AUUSDT
-    ? getAuLpSupplyInUsd(amount, avgExchangeRate)
-    : new TokenAmount(
-        lpToken,
-        JSBI.divide(JSBI.multiply(virtualPrice.raw, amount.raw), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(18)))
-      )
-}
-
-export function getAuLpSupplyInUsd(lpBalance: CurrencyAmount, avgExchangeRate: JSBI) {
+export function getLpTokenUsdEstimate(lpTokenPriceUSDC: TokenAmount, amount: CurrencyAmount) {
   return new TokenAmount(
     USDC[ChainId.AURORA],
-    JSBI.divide(
-      JSBI.multiply(JSBI.divide(lpBalance.raw, JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(10))), avgExchangeRate),
-      JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(18))
-    )
+    JSBI.divide(JSBI.multiply(lpTokenPriceUSDC.raw, amount.raw), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(18)))
   )
-}
-
-export function getBalanceConversionForStablePoolType(
-  poolType: StableSwapPoolTypes,
-  balance: JSBI,
-  token: Token,
-  exchangeRate: JSBI
-): TokenAmount {
-  if (
-    poolType === StableSwapPoolTypes.BTC ||
-    poolType === StableSwapPoolTypes.ETH ||
-    poolType === StableSwapPoolTypes.USD
-  ) {
-    return new TokenAmount(token, balance)
-  } else if (poolType === StableSwapPoolTypes.AURIGAMI) {
-    return new TokenAmount(
-      token,
-      JSBI.divide(
-        JSBI.multiply(JSBI.BigInt(balance), exchangeRate),
-        JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(18))
-      )
-    )
-  } else {
-    throw new Error('[getTokenForStablePoolType] Error getting tokenAmount conversion')
-  }
 }


### PR DESCRIPTION
- Add AuErc20 tokens price  in USDC calculation in getUDSCPrice hook. 
- Remove custom functions for aurigami pool for calculating $tvl and balances
- Rework balances, lpTokenPrice and TVL calculation  and add/remove liquidity usd estimatations:
  - Balances in usd are calculated with token price
  - $TVL is sum of reserves in usd
  - lpTokenPrice is $TVL / total supply
  - add/remove liq usd estimation uses lpTokenprice 

<img width="742" alt="Screen Shot 2022-09-19 at 19 47 48" src="https://user-images.githubusercontent.com/96993065/191080948-fd7a5c2f-d0fd-4f71-b25d-880760a8f119.png">

<img width="712" alt="Screen Shot 2022-09-19 at 19 47 58" src="https://user-images.githubusercontent.com/96993065/191080975-966f5c90-bb0f-42a7-9d66-d127b921e2c6.png">
