### PR TITLE
Remove rewarder from AURORA-ETH. Move to TRI only

### DIFF
--- a/src/constants/farms.ts
+++ b/src/constants/farms.ts
@@ -1,6 +1,6 @@
-export const DUAL_REWARDS_POOLS = [8, 30, 7, 15, 19, 38, 37, 41, 43]
+export const DUAL_REWARDS_POOLS = [30, 15, 19, 38, 37, 41, 43]
 
-export const TRI_ONLY_REWARDS_POOLS = [5, 11, 0, 3, 4, 31, 32, 33, 40]
+export const TRI_ONLY_REWARDS_POOLS = [7, 8, 5, 11, 0, 3, 4, 31, 32, 33, 40]
 
 export const ECOSYSTEM_POOLS = [20, 24, 34, 42]
 

--- a/src/state/stake/stake-constants.ts
+++ b/src/state/stake/stake-constants.ts
@@ -246,17 +246,14 @@ const AURORA_POOLS: StakingTri[] = [
     poolId: 0,
     tokens: [AURORA[ChainId.AURORA], WETH[ChainId.AURORA]],
     lpAddress: '0x5eeC60F348cB1D661E4A5122CF4638c7DB7A886e',
-    rewarderAddress: '0x94669d7a170bfe62FAc297061663e0B48C63B9B5',
-    allocPoint: 1,
-    isFeatured: true
+    allocPoint: 1
   }),
   createMCV2Pool({
     ID: 8,
     poolId: 1,
     tokens: [TRI[ChainId.AURORA], AURORA[ChainId.AURORA]],
     lpAddress: '0xd1654a7713617d41A8C9530Fb9B948d00e162194',
-    allocPoint: 1,
-    isFeatured: true
+    allocPoint: 1
   }),
   createMCV2Pool({
     ID: 9,


### PR DESCRIPTION
- Remove Rewarder from AURORA-ETH
- Move TRI-AURORA and AURORA-ETH to TRI only farms

<img width="737" alt="Screen Shot 2022-09-20 at 22 23 05" src="https://user-images.githubusercontent.com/96993065/191357249-312fd74f-7c99-46de-81c4-391f84c485c1.png">
