### PR TITLE
Removed dollar sign; Updated description

### DIFF
--- a/src/components/PositionCard/StablePositionCard/index.tsx
+++ b/src/components/PositionCard/StablePositionCard/index.tsx
@@ -1,4 +1,3 @@
-import { Pair } from '@trisolaris/sdk'
 import { darken } from 'polished'
 import React, { useState, useContext } from 'react'
 import { Text } from 'rebass'
@@ -102,12 +101,6 @@ const CurrencyContainer = styled.div`
   align-items: center;
 `
 
-interface PositionCardProps {
-  pair: Pair
-  showUnwrapped?: boolean
-  border?: string
-}
-
 interface StablePositionCardProps {
   poolName: StableSwapPoolName
   showUnwrapped?: boolean
@@ -145,13 +138,6 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
   }
 
   const poolTVL = stablePoolData.totalLocked?.toFixed(0)
-  const formattedPoolData = [
-    {
-      label: 'Virtual Price',
-      value: stablePoolData.virtualPrice == null ? '-' : `$${stablePoolData.virtualPrice?.toFixed(6)}`,
-      tooltipData: 'Average dollar value of pool token.'
-    }
-  ]
 
   const handleCardClick = () => {
     setShowMore(!showMore)
@@ -233,8 +219,11 @@ export default function FullStablePositionCard({ poolName, border }: StablePosit
               <TYPE.subHeader fontSize={16} fontWeight={600} marginTop="8px">
                 Pool Info
               </TYPE.subHeader>
-              {formattedPoolData.map(({ label, value, tooltipData }) => renderRow({ label, value, tooltipData }))}
-
+              {renderRow({
+                label: 'Virtual Price',
+                value: stablePoolData.virtualPrice?.toFixed(6) ?? '-',
+                tooltipData: 'Value of LP relative to underlying assets.'
+              })}
               <TYPE.subHeader fontSize={16} fontWeight={600} marginTop="8px">
                 Contracts
               </TYPE.subHeader>


### PR DESCRIPTION
Updated tooltip and removed `$`.  This is more accurate with the introduction of non-USD pools.

Before:
<img width="796" alt="image" src="https://user-images.githubusercontent.com/94581898/191569561-13725582-d4e9-4c8c-b661-a73e251ee598.png">


After:
<img width="792" alt="image" src="https://user-images.githubusercontent.com/94581898/191569496-7febad0f-31bd-4049-a43b-58aba1cce85f.png">
