### PR TITLE
Fix Network button adding AURORA instead of switching to AURORA+ if available

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "interface",
   "description": "Trisolaris Interface",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "homepage": ".",
   "private": true,
   "devDependencies": {

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -279,18 +279,28 @@ export default function WalletModal({
     })
   }
 
-  function addNetwork() {
+  async function addNetwork() {
     const chainID: ChainId = NETWORK_CHAIN_ID
-    injected.getProvider().then(provider => {
-      provider
-        .request({
-          method: 'wallet_addEthereumChain',
-          params: [CHAIN_PARAMS[chainID]]
-        })
-        .catch((error: any) => {
-          console.log(error)
-        })
-    })
+    const provider = await injected.getProvider()
+    try {
+      await provider.request({
+        method: 'wallet_switchEthereumChain',
+        params: [{ chainId: CHAIN_PARAMS[chainID].chainId }]
+      })
+    } catch (switchError) {
+      // This error code indicates that the chain has not been added to MetaMask.
+      if ((switchError as any)?.code === 4902) {
+        try {
+          await provider.request({
+            method: 'wallet_addEthereumChain',
+            params: [CHAIN_PARAMS[chainID]]
+          })
+        } catch (addError) {
+          console.log(addError)
+        }
+      }
+      console.log(switchError)
+    }
   }
 
   function getModalContent() {

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -283,23 +283,24 @@ export default function WalletModal({
     const chainID: ChainId = NETWORK_CHAIN_ID
     const provider = await injected.getProvider()
     try {
-      await provider.request({
-        method: 'wallet_switchEthereumChain',
-        params: [{ chainId: CHAIN_PARAMS[chainID].chainId }]
-      })
-    } catch (switchError) {
-      // This error code indicates that the chain has not been added to MetaMask.
-      if ((switchError as any)?.code === 4902) {
-        try {
-          await provider.request({
-            method: 'wallet_addEthereumChain',
-            params: [CHAIN_PARAMS[chainID]]
-          })
-        } catch (addError) {
-          console.log(addError)
+      try {
+        await provider.request({
+          method: 'wallet_switchEthereumChain',
+          params: [{ chainId: CHAIN_PARAMS[chainID].chainId }]
+        })
+      } catch (e) {
+        // This error code indicates that the chain has not been added to MetaMask.
+        if ((e as any)?.code !== 4902) {
+          throw e
         }
+
+        await provider.request({
+          method: 'wallet_addEthereumChain',
+          params: [CHAIN_PARAMS[chainID]]
+        })
       }
-      console.log(switchError)
+    } catch (e) {
+      console.error(e)
     }
   }
 


### PR DESCRIPTION
- Replace default function of wallet button ``wallet_addEthereumChain``  by ``wallet_switchEthereumChain``.  In this way, if the user has Aurora+ available, it will switch to it instead of adding Aurora(not plus) as a new chain.
- Reformat function from promise chain to async-await.

### Before ###
#### Example of a user using Aurora+, currently on ethereum mainnet ####

<img width="411" alt="Screen Shot 2022-09-22 at 14 42 31" src="https://user-images.githubusercontent.com/96993065/191751905-2ba172ab-bbcd-447f-b578-292e0021161f.png">
<img width="1103" alt="Screen Shot 2022-09-22 at 14 42 37" src="https://user-images.githubusercontent.com/96993065/191752049-694a5c5a-388e-4daa-b71a-1b00983ff88b.png">

### After ###
<img width="764" alt="Screen Shot 2022-09-22 at 14 42 57" src="https://user-images.githubusercontent.com/96993065/191752089-5394c9e4-2a89-40de-afd7-07b6047131a6.png">

