### PR TITLE
Fix border-radius and padding

### DIFF
--- a/src/components/earn/PoolCardTri/PoolCardTri.styles.tsx
+++ b/src/components/earn/PoolCardTri/PoolCardTri.styles.tsx
@@ -20,7 +20,7 @@ export const Wrapper = styled(Card)<{
   border-radius: 0px;
   gap: 12px;
   position: relative;
-  padding: 10px 20px 16px 20px;
+  padding: 12px 20px 12px 20px;
   display: grid;
   grid-auto-rows: auto;
 
@@ -30,6 +30,9 @@ export const Wrapper = styled(Card)<{
   }
   &:last-child {
     border-radius: 0 0 10px 10px;
+  }
+  &:only-child {
+    border-radius: 10px;
   }
 
   &:hover {


### PR DESCRIPTION
- Fix border radius not applying when only 1 card
- Made padding equal on top and bottom.




### Padding Before: ###
<img width="1326" alt="Screen Shot 2022-09-30 at 16 37 04" src="https://user-images.githubusercontent.com/96993065/193295443-81cd9066-26ae-4b5d-9dda-cb3b19378ea7.png">

### After: ###
<img width="1293" alt="Screen Shot 2022-09-30 at 16 36 51" src="https://user-images.githubusercontent.com/96993065/193295436-680ad6a8-3c32-4189-b49a-f1f4ffdba124.png">

### Radius Before ###
<img width="756" alt="Screen Shot 2022-09-30 at 16 37 10" src="https://user-images.githubusercontent.com/96993065/193295450-67b98789-cd2e-493f-9ab0-7f1cd8d8877f.png">


### After ###

<img width="730" alt="Screen Shot 2022-09-30 at 16 35 23" src="https://user-images.githubusercontent.com/96993065/193295422-c43594c1-c474-459d-a270-08a874717c52.png">