### PR TITLE
TRI WNEAR changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "interface",
   "description": "Trisolaris Interface",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "homepage": ".",
   "private": true,
   "devDependencies": {

--- a/src/constants/farms.ts
+++ b/src/constants/farms.ts
@@ -1,9 +1,9 @@
 export const DUAL_REWARDS_POOLS = [30, 15, 19, 38, 37, 41, 43, 45]
 
-export const TRI_ONLY_REWARDS_POOLS = [7, 8, 5, 11, 0, 3, 4, 31, 32, 33, 40]
+export const TRI_ONLY_REWARDS_POOLS = [7, 8, 11, 0, 3, 4, 31, 32, 33, 40]
 
 export const ECOSYSTEM_POOLS = [20, 24, 34, 42]
 
 export const STABLE_POOLS = [35, 39, 44]
 
-export const LEGACY_POOLS = [1, 2, 6, 16, 12, 13, 14, 9, 10, 21, 22, 17, 18, 23, 27, 26, 28, 29, 36]
+export const LEGACY_POOLS = [1, 2, 6, 16, 12, 13, 14, 9, 10, 21, 22, 17, 18, 23, 27, 26, 28, 29, 36, 5]

--- a/src/state/stake/stake-constants.ts
+++ b/src/state/stake/stake-constants.ts
@@ -233,7 +233,6 @@ const AURORA_POOLS: StakingTri[] = [
     tokens: [TRI[ChainId.AURORA], WNEAR[ChainId.AURORA]],
     lpAddress: '0x84b123875F0F36B966d0B6Ca14b31121bd9676AD',
     allocPoint: 1,
-    isPeriodFinished: true
   }),
   createMCV1Pool({
     ID: 6,
@@ -582,7 +581,6 @@ const AURORA_POOLS: StakingTri[] = [
     lpAddress: '0x84b123875F0F36B966d0B6Ca14b31121bd9676AD',
     rewarderAddress: '0x7b0C1534ba1c2945fED6f906A538a63E5EE3418D',
     isFeatured: true,
-    inStaging: true
   })
 ]
 


### PR DESCRIPTION
- Move mcv1 TRI-WNEAR farm to legacy.
- Remove mcv2 TRI-WNEAR farm from staging.

### MCV2 Farm:
<img width="390" alt="Screen Shot 2022-10-05 at 11 41 08" src="https://user-images.githubusercontent.com/96993065/194030997-4fe48520-0faf-4f0f-b057-12c71b601550.png">

### MCV1 Farm
<img width="765" alt="Screen Shot 2022-10-05 at 11 41 18" src="https://user-images.githubusercontent.com/96993065/194031000-b3215d77-01d7-4c08-bd0a-7969fbb2cb28.png">
