### PR TITLE
Add transition for toggle

### DIFF
--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -6,34 +6,49 @@ import { darken } from 'polished'
 const ToggleElement = styled.span<{ isActive?: boolean; isOnSwitch?: boolean; fontSize?: string }>`
   padding: 0.25rem 0.5rem;
   border-radius: 14px;
-  background: ${({ theme, isActive, isOnSwitch }) => (isActive ? (isOnSwitch ? theme.primary1 : theme.text4) : 'none')};
   color: ${({ theme, isActive, isOnSwitch }) => (isActive ? (isOnSwitch ? theme.white : theme.text2) : theme.text3)};
   font-size: 1rem;
   font-weight: 400;
 
   padding: 0.35rem 0.6rem;
   border-radius: 12px;
-  background: ${({ theme, isActive }) => (isActive ? theme.primary1 : 'none')};
   color: ${({ theme, isActive, isOnSwitch }) => (isActive ? (isOnSwitch ? theme.white : theme.text2) : theme.text2)};
   font-size: ${({ fontSize }) => (fontSize ? fontSize : '1rem')};
   font-weight: ${({ isOnSwitch }) => (isOnSwitch ? '500' : '400')};
+
+
+  position:relative;
   :hover {
     user-select: ${({ isOnSwitch }) => (isOnSwitch ? 'none' : 'initial')};
-    background: ${({ theme, isActive }) => (isActive ? darken(0.12, theme.primary1) : 'none')};
     color: ${({ theme }) => theme.text3};
   }
+
 `
 
 const StyledToggle = styled.button<{ isActive?: boolean; activeElement?: boolean }>`
   border-radius: 12px;
   border: none;
-  // border: 1px solid ${({ theme, isActive }) => (isActive ? theme.primary5 : theme.text4)}; 
   background: ${({ theme }) => theme.bg3};
   display: flex;
   width: fit-content;
   cursor: pointer;
   outline: none;
   padding: 0;
+
+  position: relative;
+  &:before {
+    transition: 0.3s;
+    content: '';
+    display: block;
+    width: 50%;
+    height: 100%;
+    position: absolute;
+    left: 0;
+    top: 0;
+    background: ${({ theme }) => theme.primary1};
+    left: ${({ isActive }) => (isActive ? 0 : '50%')};
+    border-radius: 14px;
+  }
 `
 
 export interface ToggleProps {

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -20,7 +20,6 @@ const ToggleElement = styled.span<{ isActive?: boolean; isOnSwitch?: boolean; fo
   position:relative;
   :hover {
     user-select: ${({ isOnSwitch }) => (isOnSwitch ? 'none' : 'initial')};
-    color: ${({ theme }) => theme.text3};
   }
 
 `

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -10,7 +10,7 @@ const ToggleElement = styled.span<{ isActive?: boolean; isOnSwitch?: boolean; fo
   font-size: 1rem;
   font-weight: 400;
 
-  padding: 0.35rem 0.6rem;
+  padding: 0.35rem 0.7rem;
   border-radius: 12px;
   color: ${({ theme, isActive, isOnSwitch }) => (isActive ? (isOnSwitch ? theme.white : theme.text2) : theme.text2)};
   font-size: ${({ fontSize }) => (fontSize ? fontSize : '1rem')};


### PR DESCRIPTION
 - Add transition for toggles.
- Rework background to enable transition (Use transform instead of disabling and enabling background).

#### Edit:
 Adding videos too, since second gif is really clunky, Idk why

## Before:
![before](https://user-images.githubusercontent.com/96993065/194065408-e9d9ff24-94ab-43c6-ad44-49777d0b4dca.gif)

https://user-images.githubusercontent.com/96993065/194065514-620ea7d3-9abb-4cef-bd5d-c813c9201107.mov


---

## After:
![after](https://user-images.githubusercontent.com/96993065/194065426-6755df1e-6886-4587-8a23-d59382eb203d.gif)


https://user-images.githubusercontent.com/96993065/194065537-65a47d5e-2e3a-4555-a686-e355fddae6cf.mov

