### PR TITLE
Fix apr not showing if it rounds to zero

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "interface",
   "description": "Trisolaris Interface",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "homepage": ".",
   "private": true,
   "devDependencies": {

--- a/src/components/earn/PoolCardTri/PoolCardTriRewardText.tsx
+++ b/src/components/earn/PoolCardTri/PoolCardTriRewardText.tsx
@@ -12,7 +12,7 @@ import _ from 'lodash'
 import CurrencyLogo from '../../CurrencyLogo'
 import useGetTokenByAddress from '../../../hooks/useGetTokenByAddress'
 
-import { roundApr } from '../../../utils'
+import { roundDecimal } from '../../../utils'
 
 const IconWrapper = styled.div`
   ${({ theme }) => theme.flexColumnNoWrap};
@@ -102,7 +102,7 @@ export default function PoolCardTriRewardText({ apr, inStaging, nonTriAPRs, isLe
   }
 
   // If multiple rewards, render aggregate APR, token logos, and tooltip
-  const totalAPR = roundApr((nonTriAPRs ?? []).reduce((acc, { apr: nonTriAPR }) => acc + nonTriAPR, apr))
+  const totalAPR = (nonTriAPRs ?? []).reduce((acc, { apr: nonTriAPR }) => acc + nonTriAPR, apr)
   return (
     <Popover content={tooltipContent} show={show}>
       <IconWrapper onMouseEnter={open} onMouseLeave={close}>
@@ -110,7 +110,7 @@ export default function PoolCardTriRewardText({ apr, inStaging, nonTriAPRs, isLe
           <CurrencyLogo alt="" currency={token} key={token.address} size={'16px'} style={{ marginRight: '4px' }} />
         ))}
         <TYPE.white marginRight="4px" textAlign="end">
-          {totalAPR}%
+          {roundDecimal(totalAPR)}%
         </TYPE.white>
         <Info size="16px" />
       </IconWrapper>

--- a/src/components/earn/PoolCardTri/PoolCardTriRewardText.tsx
+++ b/src/components/earn/PoolCardTri/PoolCardTriRewardText.tsx
@@ -12,6 +12,8 @@ import _ from 'lodash'
 import CurrencyLogo from '../../CurrencyLogo'
 import useGetTokenByAddress from '../../../hooks/useGetTokenByAddress'
 
+import { roundApr } from '../../../utils'
+
 const IconWrapper = styled.div`
   ${({ theme }) => theme.flexColumnNoWrap};
   display: flex;
@@ -100,7 +102,7 @@ export default function PoolCardTriRewardText({ apr, inStaging, nonTriAPRs, isLe
   }
 
   // If multiple rewards, render aggregate APR, token logos, and tooltip
-  const totalAPR = (nonTriAPRs ?? []).reduce((acc, { apr: nonTriAPR }) => acc + nonTriAPR, apr)
+  const totalAPR = roundApr((nonTriAPRs ?? []).reduce((acc, { apr: nonTriAPR }) => acc + nonTriAPR, apr))
   return (
     <Popover content={tooltipContent} show={show}>
       <IconWrapper onMouseEnter={open} onMouseLeave={close}>

--- a/src/state/stake/useFarmsAPI.ts
+++ b/src/state/stake/useFarmsAPI.ts
@@ -4,6 +4,8 @@ import { useActiveWeb3React } from '../../hooks'
 import { useFetchStakingInfoData } from '../../fetchers/farms'
 import React, { useRef } from 'react'
 
+import { roundApr } from '../../utils'
+
 // gets the staking info from the network for the active chain id
 export function useFarmsAPI(): StakingTriFarms[] {
   const { chainId } = useActiveWeb3React()
@@ -24,8 +26,8 @@ export function useFarmsAPI(): StakingTriFarms[] {
     const { totalStakedInUSD, totalRewardRate, apr: _apr, nonTriAPRs: _nonTriAPRs = [] } =
       stakingInfoData?.[index] ?? {}
 
-    const apr = Math.round(_apr ?? 0)
-    const nonTriAPRs = _nonTriAPRs.filter(({ apr }) => apr > 0).map(data => ({ ...data, apr: Math.round(data.apr) }))
+    const apr = roundApr(_apr ?? 0)
+    const nonTriAPRs = _nonTriAPRs.filter(({ apr }) => apr > 0).map(data => ({ ...data, apr: roundApr(data.apr) }))
 
     return {
       ...activeFarms[index],

--- a/src/state/stake/useFarmsAPI.ts
+++ b/src/state/stake/useFarmsAPI.ts
@@ -4,7 +4,7 @@ import { useActiveWeb3React } from '../../hooks'
 import { useFetchStakingInfoData } from '../../fetchers/farms'
 import React, { useRef } from 'react'
 
-import { roundApr } from '../../utils'
+import { roundDecimal } from '../../utils'
 
 // gets the staking info from the network for the active chain id
 export function useFarmsAPI(): StakingTriFarms[] {
@@ -26,8 +26,8 @@ export function useFarmsAPI(): StakingTriFarms[] {
     const { totalStakedInUSD, totalRewardRate, apr: _apr, nonTriAPRs: _nonTriAPRs = [] } =
       stakingInfoData?.[index] ?? {}
 
-    const apr = roundApr(_apr ?? 0)
-    const nonTriAPRs = _nonTriAPRs.filter(({ apr }) => apr > 0).map(data => ({ ...data, apr: roundApr(data.apr) }))
+    const apr = roundDecimal(_apr ?? 0)
+    const nonTriAPRs = _nonTriAPRs.filter(({ apr }) => apr > 0).map(data => ({ ...data, apr: roundDecimal(data.apr) }))
 
     return {
       ...activeFarms[index],

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -137,6 +137,6 @@ export function replaceUnderscoresWithSlashes(value: string) {
   return value.replace(/_/g, '/')
 }
 
-export function roundApr(apr: number) {
-  return apr > 1 ? Math.round(apr) : +apr?.toFixed(2)
+export function roundDecimal(apr: number) {
+  return apr >= 1 ? Math.round(apr) : +apr.toFixed(2)
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -136,3 +136,7 @@ export function divideCurrencyAmountByNumber(numerator: CurrencyAmount | undefin
 export function replaceUnderscoresWithSlashes(value: string) {
   return value.replace(/_/g, '/')
 }
+
+export function roundApr(apr: number) {
+  return apr > 1 ? Math.round(apr) : +apr?.toFixed(2)
+}


### PR DESCRIPTION
- Round only if APR is greater than 1.
- Show  0.xx% APR in tooltip, but round it in total APR% (as all APR's are currently rounded, to maintain consistency)


### Preview with TRI APR of 0.48%

#### Before:
<img width="393" alt="Screen Shot 2022-10-11 at 20 33 34" src="https://user-images.githubusercontent.com/96993065/195171836-12202b50-edb8-426e-be0b-67a01ac47d22.png">


### After:
<img width="448" alt="Screen Shot 2022-10-11 at 20 32 24" src="https://user-images.githubusercontent.com/96993065/195171792-f48d4a9d-d1e0-43e5-b50d-3e423a5ad3ec.png">
