### PR TITLE
Farms ui minor fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "interface",
   "description": "Trisolaris Interface",
-  "version": "0.2.37",
+  "version": "0.2.38",
   "homepage": ".",
   "private": true,
   "devDependencies": {

--- a/src/components/SponsoredFarmLink/SponsoredFarmLink.styles.tsx
+++ b/src/components/SponsoredFarmLink/SponsoredFarmLink.styles.tsx
@@ -29,4 +29,7 @@ export const StyledExternalLink = styled(ExternalLink)`
   ${({ theme }) => theme.mediaWidth.upToExtraSmall`
     left:45px;
   `};
+  ${({ theme }) => theme.mediaWidth.upToXxSmall`
+    left: 12px;
+  `};
 `

--- a/src/components/earn/PoolCardTri/PoolCardTri.styles.tsx
+++ b/src/components/earn/PoolCardTri/PoolCardTri.styles.tsx
@@ -44,7 +44,7 @@ export const Wrapper = styled(Card)<{
   ${({ theme }) => theme.mediaWidth.upToSmall`
         padding-left: 8px;
         padding-right: 10px;
-        min-height: 73px;
+        min-height: 39px;
     `};
 `
 
@@ -107,6 +107,7 @@ export const TokenPairBackgroundColor = styled.span<{ bgColor1: string | null; b
 export const StyledPairContainer = styled(PairContainer)`
   max-width: 200px;
   justify-self: flex-start;
+  align-self: center;
 `
 
 export const CardContainer = styled.div`
@@ -114,11 +115,12 @@ export const CardContainer = styled.div`
   grid-template-columns: 220px auto 110px 140px 100px;
   row-gap: 20px;
   width: 100%;
-  align-items: center;
+  align-items: start;
   justify-items: center;
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
     grid-template-columns: 1fr 1fr 92px;
+    grid-template-rows: 53px;
   `};
   ${({ theme }) => theme.mediaWidth.upToExtraSmall`
     grid-template-columns: 167.5px  auto 92px;
@@ -141,6 +143,9 @@ export const DetailsContainer = styled.div`
 
 export const StyledMutedSubHeader = styled(TYPE.mutedSubHeader)`
   display: flex;
+  ${({ theme }) => theme.mediaWidth.upToXxSmall`
+    font-size: 13px !important;
+  `};
 `
 
 export const RewardColumn = styled.div`
@@ -171,16 +176,16 @@ export const StyledRewardAmount = styled.span`
   text-overflow: ellipsis;
 `
 
-export const StyledLongClaimableHeader = styled(TYPE.mutedSubHeader)`
+export const StyledLongClaimableHeader = styled(StyledMutedSubHeader)`
   ${({ theme }) => theme.mediaWidth.upToSmall`
     display:none;
   `};
 `
 
-export const StyledShortClaimableHeader = styled(TYPE.mutedSubHeader)`
+export const StyledShortClaimableHeader = styled(StyledMutedSubHeader)`
   display: none;
   ${({ theme }) => theme.mediaWidth.upToSmall`
-    display:block;
+    display:flex;
   `};
 `
 
@@ -215,6 +220,7 @@ export const AprContainer = styled(AutoColumn)`
   min-width: 50px;
   justify-content: flex-start;
   justify-self: start;
+
   ${({ theme }) => theme.mediaWidth.upToSmall`
     justify-self: start;
   `};
@@ -277,6 +283,7 @@ export const ButtonWrapper = styled.div`
   width: 100%;
   max-width: 74px;
   justify-self: start;
+  align-self: center;
   ${({ theme }) => theme.mediaWidth.upToSmall`
     font-size: 14px;
     max-width: 55px;
@@ -290,6 +297,7 @@ export const StyledClaimableRewards = styled(ClaimableRewards)`
     grid-row: 2;
     grid-column: 2/3;
     display: ${({ isStaking }) => (isStaking ? 'grid' : 'none')};
+    align-self: start;
   `};
 `
 
@@ -344,9 +352,9 @@ export const UserStakedInTLP = styled(TYPE.white)`
   `};
 `
 
-export const PoolTypeHeader = styled(TYPE.mutedSubHeader)`
+export const PoolTypeHeader = styled(StyledMutedSubHeader)`
   ${({ theme }) => theme.mediaWidth.upToSmall`
-    line-height:20px;
+    line-height:23px;
   `};
 `
 

--- a/src/components/earn/PoolCardTri/PoolCardTri.styles.tsx
+++ b/src/components/earn/PoolCardTri/PoolCardTri.styles.tsx
@@ -318,7 +318,7 @@ export const StakeContainer = styled(AutoColumn)`
     grid-column: 2/4
     grid-row: ${({ isStaking }) => (isStaking ? 3 : 2)};
     padding: 0px;
-    max-width: 250px;
+
     justify-self: end;
   `};
   ${({ theme }) => theme.mediaWidth.upToExtraSmall<{ isStaking: boolean }>`

--- a/src/components/earn/PoolCardTri/index.tsx
+++ b/src/components/earn/PoolCardTri/index.tsx
@@ -192,7 +192,7 @@ const DefaultPoolCardtri = ({
                   {enableClaimButton ? (
                     <>
                       <UserStakedInUsd>~{addCommasToNumber(userStakedInUSD ?? '')}</UserStakedInUsd>/{' '}
-                      <UserStakedInTLP>{stakedAmount?.toSignificant(2)} TLP</UserStakedInTLP>
+                      <UserStakedInTLP>{stakedAmount?.toSignificant(6)} TLP</UserStakedInTLP>
                     </>
                   ) : (
                     <TYPE.white fontWeight={500}>$0</TYPE.white>


### PR DESCRIPTION


- Fix expanded card content jumping on staked TRI only farms.
- Fix TLP significant digits
- Fix alignements in expanded card in Mobile.
- Fix Alignement in responsive intermediate widths.
- Fix sponsored link overflowing in <360px widths.

### Before:
https://user-images.githubusercontent.com/96993065/205661064-9033b122-8097-4052-8c6a-08c56acc9bcf.mp4

### After: 
https://user-images.githubusercontent.com/96993065/205661088-52ea6e54-aaeb-425a-ace9-ae658e27c554.mp4

### Before:
<img width="102" alt="Screen Shot 2022-11-30 at 13 18 22" src="https://user-images.githubusercontent.com/96993065/204851613-8ca4a556-1f9b-4fc6-8028-593b602e21e4.png">

### After:
<img width="110" alt="Screen Shot 2022-11-30 at 13 18 15" src="https://user-images.githubusercontent.com/96993065/204851633-60dc57ec-31bf-477f-95ff-d8810b78a52b.png">

### Before:
<img width="365" alt="Screen Shot 2022-12-05 at 00 36 53" src="https://user-images.githubusercontent.com/96993065/205661240-950be9df-231b-49b1-b1ff-5a249d00887d.png">

### After:
<img width="364" alt="Screen Shot 2022-12-05 at 00 36 40" src="https://user-images.githubusercontent.com/96993065/205661229-17d888b0-9726-4305-80e8-c0b96baed1ae.png">

### Before
<img width="348" alt="Screen Shot 2022-12-05 at 00 37 32" src="https://user-images.githubusercontent.com/96993065/205661879-6d13fcae-a472-4835-a5ed-6d0e2eb57d82.png">

### After
<img width="370" alt="Screen Shot 2022-12-05 at 00 37 11" src="https://user-images.githubusercontent.com/96993065/205661871-bf186621-e889-431f-b8b2-332cd5348fe9.png">


