### PR TITLE
feat(landing): add hero title text-shadow. Add cta's padding

### DIFF
--- a/src/pages/Landing/Landing.styles.tsx
+++ b/src/pages/Landing/Landing.styles.tsx
@@ -59,9 +59,14 @@ export const StyledHeroTitle = styled.h1`
   font-size: 30px;
   margin-bottom: 20px;
   font-weight: 500;
+  text-shadow: 0 0 10px #fff;
   ${({ theme }) => theme.mediaWidth.upToSmall`
     font-size: 24px;
   `};
+`
+
+export const InvestorsTitle = styled(StyledHeroTitle)`
+  text-shadow: none;
 `
 
 export const TitleSection = styled.div`
@@ -100,6 +105,7 @@ export const TinyAstronaut = styled.div`
 export const CallToAction = styled.div`
   display: flex;
   align-items: center;
+  padding: 0px 40px;
 `
 
 export const FarmCallToAction = styled(CallToAction)`

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -36,7 +36,8 @@ import {
   StyledListInfo,
   AuroraPlusSection,
   AuroraPlusLogoContainer,
-  AuroraPlusTitle
+  AuroraPlusTitle,
+  InvestorsTitle
 } from './Landing.styles'
 
 function Landing() {
@@ -127,7 +128,7 @@ function Landing() {
         </StyledCallToActionButton>
       </CallToActionSection>
       <AutoColumn justify="center">
-        <StyledHeroTitle>INVESTORS</StyledHeroTitle>
+        <InvestorsTitle>INVESTORS</InvestorsTitle>
         <InvestorsSection>
           <InvestorLogo>
             <StyledImg src={Electric} alt="Electric Capital logo" />


### PR DESCRIPTION
Adding hero title text shadow and some padding to farm/swap buttons

<img width="1512" alt="Screenshot 2023-04-17 at 11 39 23" src="https://user-images.githubusercontent.com/96993065/232520921-d28d83dc-b59e-44fd-8d54-62a5038eae6b.png">
