### PR TITLE
chore: move farms to legacy

### DIFF
--- a/src/constants/farms.ts
+++ b/src/constants/farms.ts
@@ -1,4 +1,4 @@
-export const DUAL_REWARDS_POOLS = [19, 51, 52]
+export const DUAL_REWARDS_POOLS = [38, 43, 51, 52]
 
 export const TRI_ONLY_REWARDS_POOLS = [7, 8, 11, 0, 3, 4, 31, 32, 33, 45]
 
@@ -6,6 +6,7 @@ export const ECOSYSTEM_POOLS = []
 
 export const STABLE_POOLS = [
   47,
+  44,
   53,
   // NOTE - this is actually mcv2 pool id 56 but evie screwed up the lp token when setting up the stableswap pool farms :(
   54
@@ -45,11 +46,9 @@ export const LEGACY_POOLS = [
   39,
   21,
   30,
-  38,
-  43,
-  46,
-  44,
-  48
+  48,
+  19,
+  46
 ]
 
 export const MULTIPLE_REWARD_POOLS = [50]

--- a/src/constants/farms.ts
+++ b/src/constants/farms.ts
@@ -1,12 +1,11 @@
-export const DUAL_REWARDS_POOLS = [30, 19, 38, 43, 46, 51, 52]
+export const DUAL_REWARDS_POOLS = [19, 51, 52]
 
 export const TRI_ONLY_REWARDS_POOLS = [7, 8, 11, 0, 3, 4, 31, 32, 33, 45]
 
-export const ECOSYSTEM_POOLS = [48]
+export const ECOSYSTEM_POOLS = []
 
 export const STABLE_POOLS = [
   47,
-  44,
   53,
   // NOTE - this is actually mcv2 pool id 56 but evie screwed up the lp token when setting up the stableswap pool farms :(
   54
@@ -44,7 +43,13 @@ export const LEGACY_POOLS = [
   35,
   15,
   39,
-  21
+  21,
+  30,
+  38,
+  43,
+  46,
+  44,
+  48
 ]
 
 export const MULTIPLE_REWARD_POOLS = [50]


### PR DESCRIPTION
Includes bstn/brrr/ply/nearx-wnear, auUSDT-auUSDC, usdc.e-nstart

## Testing
- Run `yarn && yarn start`
- Go to Farms page
- Toggle Legacy Pools
- Verify all mentioned pairs are there