### PR TITLE
build: remove project yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,8 +123,7 @@
     "ts-jest": "24.3.0",
     "typescript": "^5.0.4",
     "use-count-up": "^2.2.5",
-    "wcag-contrast": "^3.0.0",
-    "yarn": "^1.22.19"
+    "wcag-contrast": "^3.0.0"
   },
   "scripts": {
     "start": "yarn build-tokens && react-scripts start",
@@ -170,5 +169,6 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23300,11 +23300,6 @@ yargs@^17.7.2:
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
 
-yarn@^1.22.19:
-  version "1.22.19"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.19.tgz#4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
-  integrity sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ==
-
 yauzl@^2.10.0, yauzl@^2.4.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"


### PR DESCRIPTION
## Description
The current setup breaks corepack users (which is the recommended way to install yarn without npm and/or globally). To use `yarn` moving forward, do `corepack enable` from >=16.x